### PR TITLE
Change the deployment namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default | $(KUBECTL) apply --server-side -f -
-	$(KUBECTL) wait --for=condition=Available deployment --all -n tekton-kueue-system --timeout=300s
+	$(KUBECTL) wait --for=condition=Available deployment --all -n tekton-kueue --timeout=300s
 
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: tekton-kueue-system
+namespace: tekton-kueue
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -50,7 +50,7 @@ import (
 )
 
 // namespace where the project is deployed in
-const namespace = "tekton-kueue-system"
+const namespace = "tekton-kueue"
 
 // serviceAccountName created for the project
 const serviceAccountName = "tekton-kueue-controller-manager"


### PR DESCRIPTION
The current namespace is tekton-kueue-system.
Some managed clusters doesn't allowed namespace with the suffix system.

fixes: https://github.com/konflux-ci/tekton-kueue/issues/26