### PR TITLE
Give the controller permissions to update finalizers on pipelineruns

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -72,3 +72,9 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - pipelineruns/finalizers
+  verbs:
+  - update


### PR DESCRIPTION
Without it, when deploying on openshift, the controller throws the following error:

```
 is forbidden: cannot set blockOwnerDeletion if an ownerReference refers
 to a resource you can't set finalizers on:
```

fixes: https://github.com/konflux-ci/tekton-kueue/issues/27