### PR TITLE
Support Pipelinerun count

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,15 @@ You can apply the samples using:
 kubectl apply -n tekton-kueue-test -f config/samples/kueue/kueue-resources.yaml
 ```
 
-By default, the controller will assume that each PipelineRun resource requests are of 1Gi of Memory.
-This can be changed by placing annotations on the PipelineRun resource. The available annotations are:
+Resource requests can be specified by placing annotations on the PipelineRun resource. The available annotations are:
 
 - `kueue.konflux-ci.dev/requests-cpu`
 - `kueue.konflux-ci.dev/requests-memory`
 - `kueue.konflux-ci.dev/requests-storage`
 - `kueue.konflux-ci.dev/requests-ephemeral-storage`
+
+By default, a special resource called `tekton.dev/pipelineruns` is added to the [Workload] with the value of 1.
+This resource can be used for controlling the number of PipelineRuns that can be executed concurrently.
 
 You are now ready to create PipelineRuns that will get scheduled by Kueue.
 You can use the following PipelineRun definition (which prints a message to stdout after sleeping for several seconds):

--- a/config/samples/kueue/kueue-resources.yaml
+++ b/config/samples/kueue/kueue-resources.yaml
@@ -13,7 +13,7 @@ spec:
   namespaceSelector: {}
   queueingStrategy: BestEffortFIFO
   resourceGroups:
-  - coveredResources: ["cpu", "memory"]
+  - coveredResources: ["cpu", "memory", "tekton.dev/pipelineruns"]
     flavors:
     - name: "default-flavor"
       resources:
@@ -21,7 +21,8 @@ spec:
         nominalQuota: 2
       - name: "memory"
         nominalQuota: 1Gi
-
+      - name: "tekton.dev/pipelineruns"
+        nominalQuota: 2
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: LocalQueue
@@ -29,3 +30,27 @@ metadata:
   name: pipelines-queue
 spec:
   clusterQueue: cluster-pipeline-queue
+
+---
+# block running pipelines by setting the nominalQuota to 0
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: blocking-cluster-pipeline-queue
+spec:
+  namespaceSelector: {}
+  queueingStrategy: BestEffortFIFO
+  resourceGroups:
+  - coveredResources: ["tekton.dev/pipelineruns"]
+    flavors:
+    - name: "default-flavor"
+      resources:
+      - name: "tekton.dev/pipelineruns"
+        nominalQuota: 0
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata:
+  name: blocking-pipelines-queue
+spec:
+  clusterQueue: blocking-cluster-pipeline-queue

--- a/internal/controller/pipelinerun_controller.go
+++ b/internal/controller/pipelinerun_controller.go
@@ -43,8 +43,8 @@ const (
 )
 
 const (
-	ControllerName              = "KueuePipelineRunController"
-	ResourcePipelineRunCount    = "tekton.dev/pipelineruns"
+	ControllerName           = "KueuePipelineRunController"
+	ResourcePipelineRunCount = "tekton.dev/pipelineruns"
 )
 
 const (

--- a/internal/controller/pipelinerun_controller.go
+++ b/internal/controller/pipelinerun_controller.go
@@ -44,7 +44,7 @@ const (
 
 const (
 	ControllerName              = "KueuePipelineRunController"
-	PipelineRunCountResourceKey = "tekton.dev/pipelineruns"
+	ResourcePipelineRunCount    = "tekton.dev/pipelineruns"
 )
 
 const (

--- a/internal/controller/pipelinerun_controller.go
+++ b/internal/controller/pipelinerun_controller.go
@@ -187,7 +187,7 @@ func (p *PipelineRun) PodSets() []kueue.PodSet {
 // happen if they can not be parsed as `resource.Quantity`.
 func (p *PipelineRun) resourcesRequests() corev1.ResourceList {
 	requests := corev1.ResourceList{
-		PipelineRunCountResourceKey: resource.MustParse("1"),
+		ResourcePipelineRunCount: resource.MustParse("1"),
 	}
 
 	for k, v := range p.GetAnnotations() {

--- a/internal/controller/pipelinerun_controller.go
+++ b/internal/controller/pipelinerun_controller.go
@@ -43,13 +43,13 @@ const (
 )
 
 const (
-	ControllerName = "KueuePipelineRunController"
+	ControllerName              = "KueuePipelineRunController"
+	PipelineRunCountResourceKey = "tekton.dev/pipelineruns"
 )
 
 const (
 	annotationDomain            = "kueue.konflux-ci.dev/"
 	annotationResourcesRequests = annotationDomain + "requests-"
-	defaultMemoryRequest        = "1Gi"
 )
 
 var (
@@ -179,14 +179,15 @@ func (p *PipelineRun) PodSets() []kueue.PodSet {
 // * `kueue.konflux-ci.dev/requests-storage`
 // * `kueue.konflux-ci.dev/requests-ephemeral-storage`
 //
-// If no annotation is matched, this function will default
-// the memory requested to `1Gi`.
+// By default, a resource which indicates that the workload requires 1
+// PipelineRun will be added. This is useful for controlling the number
+// of PipelineRuns that can be executed concurrently.
 //
 // WARNING: Annotations are not validated and a panic will
 // happen if they can not be parsed as `resource.Quantity`.
 func (p *PipelineRun) resourcesRequests() corev1.ResourceList {
 	requests := corev1.ResourceList{
-		corev1.ResourceMemory: resource.MustParse(defaultMemoryRequest),
+		PipelineRunCountResourceKey: resource.MustParse("1"),
 	}
 
 	for k, v := range p.GetAnnotations() {

--- a/internal/webhook/v1/pipelinerun_webhook.go
+++ b/internal/webhook/v1/pipelinerun_webhook.go
@@ -70,7 +70,9 @@ func (d *PipelineRunCustomDefaulter) Default(ctx context.Context, obj runtime.Ob
 		if plr.Labels == nil {
 			plr.Labels = make(map[string]string)
 		}
-		plr.Labels[QueueLabel] = d.KueueName
+		if _, exists := plr.Labels[QueueLabel]; !exists {
+			plr.Labels[QueueLabel] = d.KueueName
+		}
 	}
 
 	return nil


### PR DESCRIPTION
1. Add special resource to the Workload created for a PipelinRun. The resource will be used for controlling the amount of concurrent PipelineRuns that can be executed at the same time.

2. Remove the default 1GB memory request, since it's not needed after the addition of the new resource request.

3. Tests refactoring for sharing assertion and making them more informative.

closes: https://github.com/konflux-ci/tekton-kueue/issues/29