### PR TITLE
feat: Add workflow to build container images with ko

### DIFF
--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -1,0 +1,48 @@
+name: Create and publish a Docker image to ghcr on main and nightly with ko
+
+on:
+  push:
+    paths:
+      - "**.go"
+      - "**.yaml"
+env:
+  PLATFORMS: linux/amd64,linux/arm64,linux/ppc64le
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+
+      - uses: ko-build/setup-ko@v0.9
+
+      - name: Build and push images
+        shell: bash
+        run: |
+          set -x
+          releaseBranchFormat='release-v'
+          if [[ ${{ github.ref_name }} == ${releaseBranchFormat}* ]]; then
+            tag=v$(echo ${{ github.ref_name }}|sed "s,${releaseBranchFormat},,")
+          elif [[ ${{ github.ref }} == refs/pull/* ]]; then
+            tag=pr-$(echo ${{ github.ref }} | cut -c11-|sed 's,/merge,,')
+          else
+            # Sanitize the tag by replacing invalid characters with hyphens
+            tag=$(echo ${{ github.ref_name }}|sed 's,/merge,,' | sed 's,[/.],-,g')
+          fi
+          for image in ./cmd/*;do
+            ko build -B -t "${tag}" --platform="${{ env.PLATFORMS }}" "${image}"
+          done


### PR DESCRIPTION
- Added a new GitHub Actions workflow (`container-build.yaml`).
- Configured the workflow to use `ko-build` for container image creation.
- Enabled building images for `linux/amd64`, `linux/arm64`, and `linux/ppc64le` platforms.
- Set up automatic push of built images to the GitHub Container Registry (GHCR).
- Triggered the workflow on push events involving Go or YAML files.