### PR TITLE
KFLUXINFRA-1857: Allow to configure lease parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint)
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -115,10 +115,19 @@ func (c *ControllerFlags) AddFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&c.EnableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	fs.DurationVar(&c.LeaseDuration, "leader-elect-lease-duration", 15*time.Second,
-		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership.")
-	fs.DurationVar(&c.RenewDeadline, "leader-elect-renew-deadline", 10*time.Second,
-		"The interval between attempts by the acting master to renew a leadership slot before it stops leading.")
+	fs.DurationVar(
+		&c.LeaseDuration,
+		"leader-elect-lease-duration",
+		15*time.Second,
+		"The duration that non-leader candidates will wait after observing a "+
+			"leadership renewal until attempting to acquire leadership.",
+	)
+	fs.DurationVar(
+		&c.RenewDeadline,
+		"leader-elect-renew-deadline",
+		10*time.Second,
+		"The interval between attempts by the acting master to renew a leadership slot before it stops leading.",
+	)
 	fs.DurationVar(&c.RetryPeriod, "leader-elect-retry-period", 2*time.Second,
 		"The duration the clients should wait between attempting acquisition and renewal of a leadership.")
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,6 +25,7 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"time"
 
 	"k8s.io/apimachinery/pkg/util/yaml"
 
@@ -104,6 +105,9 @@ func (s *SharedFlags) AddFlags(fs *flag.FlagSet) {
 type ControllerFlags struct {
 	SharedFlags
 	EnableLeaderElection bool
+	LeaseDuration        time.Duration
+	RenewDeadline        time.Duration
+	RetryPeriod          time.Duration
 }
 
 func (c *ControllerFlags) AddFlags(fs *flag.FlagSet) {
@@ -111,6 +115,12 @@ func (c *ControllerFlags) AddFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&c.EnableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	fs.DurationVar(&c.LeaseDuration, "leader-elect-lease-duration", 15*time.Second,
+		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership.")
+	fs.DurationVar(&c.RenewDeadline, "leader-elect-renew-deadline", 10*time.Second,
+		"The interval between attempts by the acting master to renew a leadership slot before it stops leading.")
+	fs.DurationVar(&c.RetryPeriod, "leader-elect-retry-period", 2*time.Second,
+		"The duration the clients should wait between attempting acquisition and renewal of a leadership.")
 }
 
 type WebhookFlags struct {
@@ -161,6 +171,10 @@ func runController(args []string) {
 		HealthProbeBindAddress: controllerFlags.ProbeAddr,
 		LeaderElection:         controllerFlags.EnableLeaderElection,
 		LeaderElectionID:       "f2ddafa2.konflux-ci.dev",
+		LeaseDuration:          &controllerFlags.LeaseDuration,
+		RenewDeadline:          &controllerFlags.RenewDeadline,
+		RetryPeriod:            &controllerFlags.RetryPeriod,
+
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"flag"
+	"testing"
+	"time"
+)
+
+func TestControllerFlags_AddFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected ControllerFlags
+	}{
+		{
+			name: "default values",
+			args: []string{},
+			expected: ControllerFlags{
+				EnableLeaderElection: false,
+				LeaseDuration:        15 * time.Second,
+				RenewDeadline:        10 * time.Second,
+				RetryPeriod:          2 * time.Second,
+			},
+		},
+		{
+			name: "custom lease duration",
+			args: []string{"--leader-elect-lease-duration=30s"},
+			expected: ControllerFlags{
+				EnableLeaderElection: false,
+				LeaseDuration:        30 * time.Second,
+				RenewDeadline:        10 * time.Second,
+				RetryPeriod:          2 * time.Second,
+			},
+		},
+		{
+			name: "all custom values",
+			args: []string{
+				"--leader-elect=true",
+				"--leader-elect-lease-duration=45s",
+				"--leader-elect-renew-deadline=20s",
+				"--leader-elect-retry-period=5s",
+			},
+			expected: ControllerFlags{
+				EnableLeaderElection: true,
+				LeaseDuration:        45 * time.Second,
+				RenewDeadline:        20 * time.Second,
+				RetryPeriod:          5 * time.Second,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var flags ControllerFlags
+			fs := flag.NewFlagSet("test", flag.ContinueOnError)
+			flags.AddFlags(fs)
+
+			err := fs.Parse(tt.args)
+			if err != nil {
+				t.Fatalf("Failed to parse flags: %v", err)
+			}
+
+			if flags.EnableLeaderElection != tt.expected.EnableLeaderElection {
+				t.Errorf("EnableLeaderElection = %v, want %v", flags.EnableLeaderElection, tt.expected.EnableLeaderElection)
+			}
+			if flags.LeaseDuration != tt.expected.LeaseDuration {
+				t.Errorf("LeaseDuration = %v, want %v", flags.LeaseDuration, tt.expected.LeaseDuration)
+			}
+			if flags.RenewDeadline != tt.expected.RenewDeadline {
+				t.Errorf("RenewDeadline = %v, want %v", flags.RenewDeadline, tt.expected.RenewDeadline)
+			}
+			if flags.RetryPeriod != tt.expected.RetryPeriod {
+				t.Errorf("RetryPeriod = %v, want %v", flags.RetryPeriod, tt.expected.RetryPeriod)
+			}
+		})
+	}
+}
+
+func TestControllerFlags_InvalidDuration(t *testing.T) {
+	var flags ControllerFlags
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	flags.AddFlags(fs)
+
+	// Test invalid duration format
+	err := fs.Parse([]string{"--leader-elect-lease-duration=invalid"})
+	if err == nil {
+		t.Error("Expected error for invalid duration format, got nil")
+	}
+}


### PR DESCRIPTION
Different cluster can require different lease parameters in order to function properly.