### PR TITLE
Add replace() CEL function for string manipulation

### DIFF
--- a/internal/cel/doc.go
+++ b/internal/cel/doc.go
@@ -74,6 +74,9 @@
 //   - priority(value: string) -> MutationRequest
 //     Creates a label mutation with key "kueue.x-k8s.io/priority-class" and the specified value
 //
+//   - replace(source: string, search: string, replacement: string) -> string
+//     Replaces all occurrences of search string with replacement string in the source string
+//
 // # Available CEL Variables
 //
 //   - pipelineRun: map<string, any> - The full PipelineRun object as a CEL-accessible map
@@ -99,6 +102,14 @@
 //	              pipelineRun.spec.params.exists(p, p.name == "build-platforms") ?
 //	              pipelineRun.spec.params.filter(p, p.name == "build-platforms")[0].value.map(
 //	                  p, annotation("kueue.konflux-ci.dev/requests-" + p, "1")
+//	              ) : []`
+//
+// Using string manipulation with replace function:
+//
+//	expression := `has(pipelineRun.spec.params) &&
+//	              pipelineRun.spec.params.exists(p, p.name == "build-platforms") ?
+//	              pipelineRun.spec.params.filter(p, p.name == "build-platforms")[0].value.map(
+//	                  p, annotation("kueue.konflux-ci.dev/requests-" + replace(p, "/", "-"), "1")
 //	              ) : []`
 //
 // # Package Structure

--- a/internal/cel/mutator_test.go
+++ b/internal/cel/mutator_test.go
@@ -22,7 +22,7 @@ const (
 	buildPlatformsExpression = `has(pipelineRun.spec.params) && pipelineRun.spec.params.exists(p, p.name == 'build-platforms') ?
 				pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value.map(
 					p,
-					annotation("kueue.konflux-ci.dev/requests-" + p, "1") 
+					annotation("kueue.konflux-ci.dev/requests-" + replace(p, "/", "-"), "1") 
 				) : []`
 )
 
@@ -430,10 +430,10 @@ func TestCELMutator_Mutate(t *testing.T) {
 			initialParams:      getBuildPlatformsParams(),
 			expectedLabels:     nil,
 			expectedAnnotations: map[string]string{
-				"kueue.konflux-ci.dev/requests-linux/arm64":   "1",
-				"kueue.konflux-ci.dev/requests-linux/amd64":   "1",
-				"kueue.konflux-ci.dev/requests-linux/s390x":   "1",
-				"kueue.konflux-ci.dev/requests-linux/ppc64le": "1",
+				"kueue.konflux-ci.dev/requests-linux-arm64":   "1",
+				"kueue.konflux-ci.dev/requests-linux-amd64":   "1",
+				"kueue.konflux-ci.dev/requests-linux-s390x":   "1",
+				"kueue.konflux-ci.dev/requests-linux-ppc64le": "1",
 			},
 			expectErr: false,
 		},
@@ -466,8 +466,8 @@ func TestCELMutator_Mutate(t *testing.T) {
 			},
 			expectedAnnotations: map[string]string{
 				"build-tool": "tekton",
-				"kueue.konflux-ci.dev/requests-linux/arm64": "1",
-				"kueue.konflux-ci.dev/requests-linux/amd64": "1",
+				"kueue.konflux-ci.dev/requests-linux-arm64": "1",
+				"kueue.konflux-ci.dev/requests-linux-amd64": "1",
 			},
 			expectErr: false,
 		},


### PR DESCRIPTION
The replace() function takes three string arguments: source, search, and replacement. It replaces all occurrences of the search string with the replacement string.

This is particularly useful for sanitizing platform names in resource annotations, converting values like 'linux/amd64' to 'linux-amd64' for Kubernetes compatibility.

- Added replace() function to CEL environment
- Added comprehensive tests for various replacement scenarios
- Updated existing tests to match new behavior
- Updated documentation with function description and examples

Assisted-By: Cursor