### PR TITLE
Add Kubernetes-compliant label/annotation key/value validation

### DIFF
--- a/internal/cel/doc.go
+++ b/internal/cel/doc.go
@@ -128,6 +128,7 @@
 //  2. Runtime input: Validates PipelineRun is not nil and properly structured
 //  3. Runtime output: Validates returned data has correct MutationRequest structure
 //  4. Field validation: Validates all required fields (type, key, value) are present and valid
+//  5. Kubernetes validation: Uses official k8s.io/apimachinery validation for annotation and label keys
 //
 // # Error Handling
 //


### PR DESCRIPTION
  Add Kubernetes-compliant label/annotation key/value validation
  
  Ensures all CEL-generated labels and annotations can be used in Kubernetes:
  
  - validateLabelKey/validateAnnotationKey: Use validation.IsQualifiedName()
  - validateLabelValue: Use validation.IsValidLabelValue() for 63-char limit
  - validateAnnotationValue: Enforce 256KB size limit
  - Update documentation to reflect validation requirements
  
  All validation uses official k8s.io/apimachinery validation functions
  to ensure compatibility with Kubernetes specifications.

Depends on: https://github.com/konflux-ci/tekton-kueue/pull/78
Assisted-By: Cursor
