### PR TITLE
feat: dynamically extract KUEUE_VERSION from go.mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller
 #ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)
 ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}')
 GOLANGCI_LINT_VERSION ?= v2.1.6
-KUEUE_VERSION ?= v0.10.2
+KUEUE_VERSION ?= $(shell ./hack/get-kueue-version.sh)
 TEKTON_VERSION ?= v0.70.0
 CERT_MANAGER_VERSION ?= v1.16.3
 

--- a/hack/get-kueue-version.sh
+++ b/hack/get-kueue-version.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Script to extract Kueue version from go.mod file
+# Usage: ./scripts/get-kueue-version.sh
+
+set -e
+
+# Check if go.mod exists
+if [ ! -f "go.mod" ]; then
+    echo "Error: go.mod file not found" >&2
+    exit 1
+fi
+
+# Extract Kueue version from go.mod
+KUEUE_VERSION=$(grep 'sigs.k8s.io/kueue' go.mod | awk '{print $2}')
+
+if [ -z "$KUEUE_VERSION" ]; then
+    echo "Error: Could not find sigs.k8s.io/kueue in go.mod" >&2
+    exit 1
+fi
+
+echo "$KUEUE_VERSION"


### PR DESCRIPTION
- Add hack/get-kueue-version.sh script to parse sigs.k8s.io/kueue version from go.mod
- Update Makefile to use script instead of hardcoded version
- Ensures KUEUE_VERSION stays in sync with go.mod dependencies automatically
- Includes error handling for missing go.mod or kueue module

Assisted-By: Cursor