### PR TITLE
feat: enhance CEL metrics for better observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,18 +308,27 @@ In addition, the tekton-kueue webhook server exposes custom Prometheus metrics f
 
 | Metric Name | Type | Description | Labels |
 |-------------|------|-------------|--------|
-| `tekton_kueue_cel_evaluation_failures_total` | Counter | Total number of CEL evaluation failures in the webhook | None |
+| `tekton_kueue_cel_evaluations_total` | Counter | Total number of CEL evaluations in the webhook | `result` (success, failure) |
 
 ### Metrics Details
 
-#### `tekton_kueue_cel_evaluation_failures_total`
+#### `tekton_kueue_cel_evaluations_total`
 
 - **Type**: Counter
-- **Purpose**: Tracks the total number of CEL expression evaluation failures that occur during PipelineRun mutation processing
-- **When incremented**: Each time a CEL expression fails to evaluate during webhook processing
+- **Purpose**: Tracks the total number of CEL expression evaluations during PipelineRun mutation processing
+- **Labels**: 
+  - `result`: The outcome of the CEL evaluation
+    - `success`: CEL expression evaluated successfully
+    - `failure`: CEL expression failed to evaluate
+- **When incremented**: 
+  - Every time CEL expressions are evaluated during webhook processing
+  - Increments with `result="success"` for successful evaluations
+  - Increments with `result="failure"` for failed evaluations
 - **Use cases**: 
-  - Monitor the health of CEL expressions in your configuration
+  - Monitor the overall health and usage of CEL expressions in your configuration
+  - Calculate error rates: `rate(tekton_kueue_cel_evaluations_total{result="failure"}[5m]) / rate(tekton_kueue_cel_evaluations_total[5m])`
   - Alert on unexpected increases in evaluation failures
+  - Track CEL expression usage patterns and performance
 
 ## Project Distribution
 

--- a/internal/cel/metrics.go
+++ b/internal/cel/metrics.go
@@ -6,22 +6,27 @@ import (
 )
 
 var (
-	// celEvaluationFailuresTotal tracks the total number of CEL evaluation failures
-	celEvaluationFailuresTotal = prometheus.NewCounterVec(
+	// celEvaluationsTotal tracks the total number of CEL evaluations
+	celEvaluationsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "tekton_kueue_cel_evaluation_failures_total",
-			Help: "Total number of CEL evaluation failures",
+			Name: "tekton_kueue_cel_evaluations_total",
+			Help: "Total number of CEL evaluations",
 		},
-		[]string{},
+		[]string{"result"}, // result can be "success" or "failure"
 	)
 )
 
 func init() {
-	// Register the metric with controller-runtime's global registry
-	metrics.Registry.MustRegister(celEvaluationFailuresTotal)
+	// Register the metrics with controller-runtime's global registry
+	metrics.Registry.MustRegister(celEvaluationsTotal)
 }
 
 // RecordEvaluationFailure increments the counter for CEL evaluation failures
 func RecordEvaluationFailure() {
-	celEvaluationFailuresTotal.WithLabelValues().Inc()
+	celEvaluationsTotal.WithLabelValues("failure").Inc()
+}
+
+// RecordEvaluationSuccess increments the counter for successful CEL evaluations
+func RecordEvaluationSuccess() {
+	celEvaluationsTotal.WithLabelValues("success").Inc()
 }

--- a/internal/cel/mutator.go
+++ b/internal/cel/mutator.go
@@ -72,6 +72,7 @@ func (m *CELMutator) evaluate(pipelineRun *tekv1.PipelineRun) ([]*MutationReques
 		}
 		allMutations = append(allMutations, mutations...)
 	}
+	RecordEvaluationSuccess()
 	return allMutations, nil
 }
 


### PR DESCRIPTION
- Replace failure-only counter with comprehensive evaluation metrics
- Add tekton_kueue_cel_evaluations_total with result label (success/failure)
- Remove deprecated tekton_kueue_cel_evaluation_failures_total metric
- Track successful CEL evaluations in addition to failures
- Update documentation with enhanced metrics details and Prometheus query examples
- Improve monitoring capabilities for CEL expression performance and error rates