### PR TITLE
KFLUXINFRA-1986: Change webhook name

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -12,7 +12,7 @@ webhooks:
       namespace: system
       path: /mutate-tekton-dev-v1-pipelinerun
   failurePolicy: Fail
-  name: mpipelinerun-v1.kb.io
+  name: pipelinerun-kueue-defaulter.tekton-kueue.io
   rules:
   - apiGroups:
     - tekton.dev

--- a/internal/webhook/v1/pipelinerun_webhook.go
+++ b/internal/webhook/v1/pipelinerun_webhook.go
@@ -43,7 +43,7 @@ type PipelineRunMutator interface {
 
 // TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-// +kubebuilder:webhook:path=/mutate-tekton-dev-v1-pipelinerun,mutating=true,failurePolicy=fail,sideEffects=None,groups=tekton.dev,resources=pipelineruns,verbs=create,versions=v1,name=mpipelinerun-v1.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-tekton-dev-v1-pipelinerun,mutating=true,failurePolicy=fail,sideEffects=None,groups=tekton.dev,resources=pipelineruns,verbs=create,versions=v1,name=pipelinerun-kueue-defaulter.tekton-kueue.io,admissionReviewVersions=v1
 
 // PipelineRunCustomDefaulter struct is responsible for setting default values on the custom resource of the
 // Kind PipelineRun when those are created or updated.


### PR DESCRIPTION
Change the webhook name from the default value kubebuilder assigns so it can be easily found in the api-server metrics.