### PR TITLE
feat: Add resource annotation summation for duplicate keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Resource requests can be specified by placing annotations on the PipelineRun res
 - `kueue.konflux-ci.dev/requests-storage`
 - `kueue.konflux-ci.dev/requests-ephemeral-storage`
 
+Additionally, dynamic resource requests can be created using CEL expressions with the `resource()` function, which automatically creates prefixed annotations (e.g., `kueue.konflux-ci.dev/requests-aws-vm-x`).
+
 By default, a special resource called `tekton.dev/pipelineruns` is added to the [Workload] with the value of 1.
 This resource can be used for controlling the number of PipelineRuns that can be executed concurrently.
 
@@ -172,6 +174,7 @@ cel:
     - 'annotation("tekton.dev/test-event-type", pacTestEventType)'
     - 'label("environment", "test")'
     - 'priority("medium")'
+    - 'resource("aws-vm-x", 2)'
     - '[annotation("build.tekton.dev/timestamp", "2025-01-01T00:00:00Z"), label("app", "test-app")]'
 ```
 
@@ -185,6 +188,7 @@ This will output the mutated PipelineRun with:
 - Applied annotations from CEL expressions (including namespace, event type, and test event type)
 - Applied labels from CEL expressions  
 - Priority class label (`kueue.x-k8s.io/priority-class`)
+- Resource request annotations (e.g., `kueue.konflux-ci.dev/requests-aws-vm-x`)
 - Queue name label (`kueue.x-k8s.io/queue-name`)
 - Status set to `PipelineRunPending`
 
@@ -294,6 +298,60 @@ The priority function automatically:
 - Can be used with dynamic expressions referencing PipelineRun fields
 - Integrates with Kueue's priority-based scheduling system
 
+##### Resource Function
+
+The `resource()` function is a specialized CEL function that creates resource request annotations with special summing behavior:
+
+- **Function**: `resource(key, value)`
+- **Parameters**: 
+  - `key`: String representing the resource name (e.g., `"aws-vm-x"`)
+  - `value`: Positive integer representing the resource quantity (must be >= 0)
+- **Purpose**: Creates annotations for resource requests with automatic key prefixing and value summing for duplicates
+- **Usage**: Enables dynamic resource allocation based on PipelineRun properties
+
+**Key Features:**
+
+1. **Automatic Key Prefixing**: Resource keys are automatically prefixed with `kueue.konflux-ci.dev/requests-`
+2. **Value Summing**: Multiple resource requests with the same key are automatically summed together
+3. **Positive Values Only**: Only non-negative integers are accepted as resource values
+4. **Type Safety**: Enforces string keys and integer values at compile time
+
+Examples:
+```yaml
+cel:
+  expressions:
+    # Single resource request
+    - 'resource("aws-vm-x", 2)'
+    
+    # Multiple resources with automatic summing
+    - 'resource("aws-vm-y", 1000)'
+    - 'resource("aws-vm-y", 500)'  # Results in total: 1500
+    
+    # Dynamic resource allocation based on PipelineRun
+    - 'resource("ibm-vm-z", pipelineRun.metadata.namespace == "production" ? 4 : 2)'
+    
+    # Combined with other mutations
+    - '[resource("aws-vm-x", 3), annotation("queue", "high-priority"), label("team", "platform")]'
+    
+    # Conditional resource allocation
+    - 'plrNamespace == "production" ? resource("aws-vm-y", 8) : resource("aws-vm-y", 4)'
+```
+
+**What happens with resource requests:**
+
+For `resource("aws-vm-x", 2)`, the function:
+1. **Validates** the key and value (key must be non-empty, value must be >= 0)
+2. **Prefixes** the key: `"aws-vm-x"` becomes `"kueue.konflux-ci.dev/requests-aws-vm-x"`
+3. **Creates** an annotation with the prefixed key and string value `"2"`
+4. **Sums** with existing values if the same resource key appears multiple times
+
+**Error Handling:**
+
+The resource function performs validation and will fail with clear error messages for:
+- Empty resource keys: `resource key cannot be empty`
+- Negative values: `resource value must be positive (>= 0), got -100`
+- Invalid key formats: Keys must follow Kubernetes annotation naming rules
+
 ### Other Subcommands
 
 - `controller` - Run the tekton-kueue controller
@@ -309,6 +367,7 @@ In addition, the tekton-kueue webhook server exposes custom Prometheus metrics f
 | Metric Name | Type | Description | Labels |
 |-------------|------|-------------|--------|
 | `tekton_kueue_cel_evaluations_total` | Counter | Total number of CEL evaluations in the webhook | `result` (success, failure) |
+| `tekton_kueue_cel_mutations_total` | Counter | Total number of CEL mutation operations applied to PipelineRuns | `result` (success, failure) |
 
 ### Metrics Details
 
@@ -329,6 +388,23 @@ In addition, the tekton-kueue webhook server exposes custom Prometheus metrics f
   - Calculate error rates: `rate(tekton_kueue_cel_evaluations_total{result="failure"}[5m]) / rate(tekton_kueue_cel_evaluations_total[5m])`
   - Alert on unexpected increases in evaluation failures
   - Track CEL expression usage patterns and performance
+
+#### `tekton_kueue_cel_mutations_total`
+
+- **Type**: Counter
+- **Purpose**: Tracks the total number of CEL mutation operations applied to PipelineRuns
+- **Labels**: 
+  - `result`: The outcome of the mutation operation
+    - `success`: All mutations applied successfully to the PipelineRun
+    - `failure`: One or more mutations failed to apply (e.g., validation errors, parsing errors)
+- **When incremented**: 
+  - Increments with `result="success"` when all mutations from CEL expressions are successfully applied to a PipelineRun
+  - Increments with `result="failure"` when any mutation fails during application (e.g., invalid resource values, annotation/label validation errors)
+- **Use cases**: 
+  - Monitor the success rate of PipelineRun mutations in the webhook
+  - Calculate mutation failure rates: `rate(tekton_kueue_cel_mutations_total{result="failure"}[5m]) / rate(tekton_kueue_cel_mutations_total[5m])`
+  - Alert on unexpected increases in mutation application failures
+  - Track the overall health of the mutation pipeline and identify configuration issues
 
 ## Project Distribution
 

--- a/internal/cel/metrics.go
+++ b/internal/cel/metrics.go
@@ -14,11 +14,21 @@ var (
 		},
 		[]string{"result"}, // result can be "success" or "failure"
 	)
+
+	// celMutationsTotal tracks the total number of CEL mutation operations
+	celMutationsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "tekton_kueue_cel_mutations_total",
+			Help: "Total number of CEL mutation operations applied to PipelineRuns",
+		},
+		[]string{"result"}, // result: "success" or "failure"
+	)
 )
 
 func init() {
 	// Register the metrics with controller-runtime's global registry
 	metrics.Registry.MustRegister(celEvaluationsTotal)
+	metrics.Registry.MustRegister(celMutationsTotal)
 }
 
 // RecordEvaluationFailure increments the counter for CEL evaluation failures
@@ -29,4 +39,14 @@ func RecordEvaluationFailure() {
 // RecordEvaluationSuccess increments the counter for successful CEL evaluations
 func RecordEvaluationSuccess() {
 	celEvaluationsTotal.WithLabelValues("success").Inc()
+}
+
+// RecordMutationFailure increments the counter for CEL mutation failures
+func RecordMutationFailure() {
+	celMutationsTotal.WithLabelValues("failure").Inc()
+}
+
+// RecordMutationSuccess increments the counter for successful CEL mutations
+func RecordMutationSuccess() {
+	celMutationsTotal.WithLabelValues("success").Inc()
 }

--- a/internal/cel/mutator.go
+++ b/internal/cel/mutator.go
@@ -1,6 +1,11 @@
 package cel
 
-import tekv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+import (
+	"fmt"
+	"strconv"
+
+	tekv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+)
 
 // CELMutator applies mutations to PipelineRun objects based on compiled CEL programs.
 // It evaluates CEL expressions and applies the resulting mutations to modify
@@ -47,8 +52,14 @@ func (m *CELMutator) Mutate(pipelineRun *tekv1.PipelineRun) error {
 	}
 
 	for _, mutation := range mutations {
-		pipelineRun = mutate(pipelineRun, mutation)
+		pipelineRun, err = mutate(pipelineRun, mutation)
+		if err != nil {
+			RecordMutationFailure()
+			return fmt.Errorf("failed to apply mutation (type: %s, key: %s): %w", mutation.Type, mutation.Key, err)
+		}
 	}
+
+	RecordMutationSuccess()
 	return nil
 }
 
@@ -77,8 +88,9 @@ func (m *CELMutator) evaluate(pipelineRun *tekv1.PipelineRun) ([]*MutationReques
 }
 
 // mutate applies a single mutation to the PipelineRun's metadata.
-// It handles both label and annotation mutations, creating the respective
-// maps if they don't exist.
+// It handles label, annotation, and resource mutations, creating the respective
+// maps if they don't exist. Resource mutations have special summing behavior
+// for duplicate keys.
 //
 // Parameters:
 //   - pipelineRun: The PipelineRun to mutate
@@ -86,7 +98,7 @@ func (m *CELMutator) evaluate(pipelineRun *tekv1.PipelineRun) ([]*MutationReques
 //
 // Returns:
 //   - *tekv1.PipelineRun: The modified PipelineRun (same instance)
-func mutate(pipelineRun *tekv1.PipelineRun, mutation *MutationRequest) *tekv1.PipelineRun {
+func mutate(pipelineRun *tekv1.PipelineRun, mutation *MutationRequest) (*tekv1.PipelineRun, error) {
 	switch mutation.Type {
 	case MutationTypeLabel:
 		if pipelineRun.Labels == nil {
@@ -98,6 +110,30 @@ func mutate(pipelineRun *tekv1.PipelineRun, mutation *MutationRequest) *tekv1.Pi
 			pipelineRun.Annotations = make(map[string]string)
 		}
 		pipelineRun.Annotations[mutation.Key] = mutation.Value
+	case MutationTypeResource:
+		if pipelineRun.Annotations == nil {
+			pipelineRun.Annotations = make(map[string]string)
+		}
+
+		// Parse the new value as integer
+		newValue, err := strconv.Atoi(mutation.Value)
+		if err != nil {
+			// This should never happen because we validate the value in the CEL compiler
+			return nil, fmt.Errorf("failed to parse resource value %q as integer: %w", mutation.Value, err)
+		}
+
+		// Check if the key already exists and sum the values
+		if existingValue, exists := pipelineRun.Annotations[mutation.Key]; exists {
+			existingInt, err := strconv.Atoi(existingValue)
+			if err != nil {
+				// This can happen if the user has manually set the value to a non-integer
+				return nil, fmt.Errorf("failed to parse existing resource value %q as integer for key %q: %w", existingValue, mutation.Key, err)
+			}
+			newValue += existingInt
+		}
+
+		// Store the summed value back as string
+		pipelineRun.Annotations[mutation.Key] = strconv.Itoa(newValue)
 	}
-	return pipelineRun
+	return pipelineRun, nil
 }

--- a/internal/cel/types.go
+++ b/internal/cel/types.go
@@ -3,6 +3,7 @@ package cel
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 )
 
 // MutationType represents the type of mutation to perform
@@ -12,16 +13,12 @@ type MutationType string
 const (
 	MutationTypeAnnotation MutationType = "annotation"
 	MutationTypeLabel      MutationType = "label"
+	MutationTypeResource   MutationType = "resource"
 )
 
 // IsValid checks if the mutation type is valid
 func (mt MutationType) IsValid() bool {
-	switch mt {
-	case MutationTypeAnnotation, MutationTypeLabel:
-		return true
-	default:
-		return false
-	}
+	return slices.Contains(ValidTypes(), mt)
 }
 
 // String returns the string representation of the mutation type
@@ -31,7 +28,7 @@ func (mt MutationType) String() string {
 
 // ValidTypes returns all valid mutation types
 func ValidTypes() []MutationType {
-	return []MutationType{MutationTypeAnnotation, MutationTypeLabel}
+	return []MutationType{MutationTypeAnnotation, MutationTypeLabel, MutationTypeResource}
 }
 
 // UnmarshalJSON implements json.Unmarshaler interface with validation

--- a/internal/cel/types_test.go
+++ b/internal/cel/types_test.go
@@ -15,6 +15,7 @@ func TestMutationType_IsValid(t *testing.T) {
 	}{
 		{"valid annotation", MutationTypeAnnotation, true},
 		{"valid label", MutationTypeLabel, true},
+		{"valid resource", MutationTypeResource, true},
 		{"invalid type", MutationType("invalid"), false},
 		{"empty type", MutationType(""), false},
 	}
@@ -46,6 +47,12 @@ func TestMutationType_JSON(t *testing.T) {
 			input:     `"label"`,
 			expectErr: false,
 			expected:  MutationTypeLabel,
+		},
+		{
+			name:      "valid resource",
+			input:     `"resource"`,
+			expectErr: false,
+			expected:  MutationTypeResource,
 		},
 		{
 			name:      "invalid type",
@@ -93,6 +100,15 @@ func TestMutationRequest_Validate(t *testing.T) {
 				Type:  MutationTypeLabel,
 				Key:   "env",
 				Value: "production",
+			},
+			expectErr: false,
+		},
+		{
+			name: "valid resource",
+			request: MutationRequest{
+				Type:  MutationTypeResource,
+				Key:   "example.com/resource-key",
+				Value: "42",
 			},
 			expectErr: false,
 		},
@@ -167,6 +183,15 @@ func TestMutationRequest_Usage(t *testing.T) {
 
 	err = label.Validate()
 	g.Expect(err).NotTo(HaveOccurred(), "Valid label should not produce error")
+
+	resource := MutationRequest{
+		Type:  MutationTypeResource,
+		Key:   "kueue.x-k8s.io/cpu-limit",
+		Value: "1000",
+	}
+
+	err = resource.Validate()
+	g.Expect(err).NotTo(HaveOccurred(), "Valid resource should not produce error")
 
 	// Test JSON marshaling/unmarshaling
 	data, err := json.Marshal(annotation)


### PR DESCRIPTION
Add ability to automatically sum resource request values when multiple CEL expressions target the same resource key. Previously, duplicate resource requests would overwrite each other - now they aggregate.

This solves the problem where complex pipelines with multiple steps or conditional branches need to accumulate resource requirements:

- Multiple pipeline tasks requesting the same VM type now sum quantities
- Conditional expressions can safely add resources without conflicts
- Eliminates need for manual resource calculation in complex workflows
- Maintains type safety with positive integer validation

Example: resource("aws-vm-x", 2) + resource("aws-vm-x", 3) = 5 total
requests, automatically creating kueue.konflux-ci.dev/requests-aws-vm-x: "5"

This enables more sophisticated resource planning for multi-step pipelines without resource request conflicts.

closes https://github.com/konflux-ci/tekton-kueue/issues/90

Assisted-By: Cursor