### PR TITLE
cel: push down eval failure metrics into program

### DIFF
--- a/internal/cel/evaluator.go
+++ b/internal/cel/evaluator.go
@@ -48,18 +48,21 @@ func (cp *CompiledProgram) Evaluate(pipelineRun *tekv1.PipelineRun) ([]*Mutation
 	// Execute the program
 	out, _, err := cp.program.Eval(vars)
 	if err != nil {
+		RecordEvaluationFailure()
 		return nil, fmt.Errorf("failed to evaluate CEL expression %q: %w", cp.expression, err)
 	}
 
 	// Convert the result to []MutationRequest with validation
 	mutations, err := convertToMutationRequests(out)
 	if err != nil {
+		RecordEvaluationFailure()
 		return nil, fmt.Errorf("failed to convert result to MutationRequests for expression %q: %w", cp.expression, err)
 	}
 
 	// Validate all mutations
 	for i, mutation := range mutations {
 		if err := mutation.Validate(); err != nil {
+			RecordEvaluationFailure()
 			return nil, fmt.Errorf("invalid mutation at index %d for expression %q: %w", i, cp.expression, err)
 		}
 	}

--- a/internal/cel/mutator.go
+++ b/internal/cel/mutator.go
@@ -78,7 +78,6 @@ func (m *CELMutator) evaluate(pipelineRun *tekv1.PipelineRun) ([]*MutationReques
 	for _, program := range m.programs {
 		mutations, err := program.Evaluate(pipelineRun)
 		if err != nil {
-			RecordEvaluationFailure()
 			return nil, err
 		}
 		allMutations = append(allMutations, mutations...)


### PR DESCRIPTION
The evaluation of a CompiledProgram has preconditions that need to be checked:
- pipelineRun is not a nil pointer
- pipelineRun can be marshalled to unstructured data (i.e. a value of type map[string]interface{})

In practice, this second condition may not always be met, since tekton's defaulting webhooks, if run prior to tekton-kueue's own webhooks, may leave the PipelineRun in a state that can't be marshalled correctly[^0]. This error gets tracked in metrics as a CEL evaluation error, even though the CEL program never got evaluated.  This further gets tracked into metrics via RecordEvaluationFailure, which will fire a SLO-level alert[^1], even though there's little that can be done by the SREs to fix it.

To work around this, push down the call to RecordEvaluationFailure into the evaluation of the CompiledProgram, silencing evaluation errors in metrics when the PipelineRun is not in a state to be evaluated.

[^0]: https://redhat-internal.slack.com/archives/C06GJAERJH2/p1755682556209569?thread_ts=1755629257.585449&cid=C06GJAERJH2
[^1]: https://github.com/redhat-appstudio/o11y/blob/a1fc78d27b4dd5f47e24331228bdf0646fe51e5b/rhobs/alerting/data_plane/prometheus.kueue_alerts.yaml#L12

Fixes: [KFLUXINFRA-2167](https://issues.redhat.com/browse/KFLUXINFRA-2167)