### PR TITLE
Add Tekton-Kueue-Config with watcher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,3 +265,9 @@ load-image: docker-build
 	$(CONTAINER_TOOL) save $(IMG) -o $${dir}/tekton-kueue.tar && \
 	kind load image-archive -n $(KIND_CLUSTER) $${dir}/tekton-kueue.tar && \
 	rm -r $${dir}
+
+# Apply tekton config  with all its dependencies.
+.PHONY: apply
+apply: docker-build docker-push release
+	$(KUBECTL) apply --server-side -f ${RELEASE_DIR}/release-${VERSION}.yaml
+	$(KUBECTL) wait --for=condition=Available deployment --all -n tekton-kueue --timeout=300s

--- a/PROJECT
+++ b/PROJECT
@@ -6,7 +6,7 @@ domain: konflux-ci.dev
 layout:
 - go.kubebuilder.io/v4
 projectName: tekton-kueue
-repo: github.com/konflux-ci/tekton-queue
+repo: github.com/konflux-ci/tekton-kueue
 resources:
 - controller: true
   domain: konflux-ci.dev

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -18,3 +18,5 @@ resources:
 - metrics_auth_role.yaml
 - metrics_auth_role_binding.yaml
 - metrics_reader_role.yaml
+- webhook_role.yaml
+- webhook_role_binding.yaml

--- a/config/rbac/webhook_role.yaml
+++ b/config/rbac/webhook_role.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: webhook-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch

--- a/config/rbac/webhook_role_binding.yaml
+++ b/config/rbac/webhook_role_binding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: tekton-kueue
+    app.kubernetes.io/managed-by: kustomize
+  name: webhook-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: webhook
+    namespace: system

--- a/config/webhook/deployment.yaml
+++ b/config/webhook/deployment.yaml
@@ -33,7 +33,6 @@ spec:
           - webhook
           - --health-probe-bind-address=:8081
           - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
-          - --config-dir=/tmp/k8s-webhook-server/kueue-config
           - --metrics-bind-address=:8443
         image: controller:latest
         name: webhook
@@ -73,15 +72,9 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: webhook-certs
           readOnly: true
-        - mountPath: /tmp/k8s-webhook-server/kueue-config
-          name: kueue-config
-          readOnly: true
       volumes:
       - name: webhook-certs
         secret:
           secretName: webhook-server-cert
-      - name: kueue-config
-        configMap:
-          name: config
       serviceAccountName: webhook
       terminationGracePeriodSeconds: 10

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -14,6 +14,10 @@ configurations:
 apiVersion: kustomize.config.k8s.io/v1beta1
 
 configMapGenerator:
-- name: config
-  files:
+- files:
   - config.yaml
+  name: config
+  options:
+    disableNameSuffixHash: true
+    labels:
+      app.kubernetes.io/part-of: tekton-kueue

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/konflux-ci/tekton-queue
+module github.com/konflux-ci/tekton-kueue
 
 go 1.24.0
 
@@ -13,6 +13,7 @@ require (
 	github.com/onsi/gomega v1.37.0
 	github.com/prometheus/client_golang v1.22.0
 	github.com/tektoncd/pipeline v1.6.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.32.8
 	k8s.io/apimachinery v0.32.9
 	k8s.io/client-go v0.32.8
@@ -117,7 +118,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.32.8 // indirect
 	k8s.io/apiserver v0.32.8 // indirect
 	k8s.io/component-base v0.32.8 // indirect

--- a/internal/common/common_utils.go
+++ b/internal/common/common_utils.go
@@ -1,0 +1,17 @@
+package common
+
+import (
+	"errors"
+	"os"
+)
+
+const namespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+
+func GetCurrentNamespace() (string, error) {
+	bytes, err := os.ReadFile(namespaceFile)
+	if err != nil {
+		return "", errors.New("not able to read  namespace file: " + namespaceFile)
+	}
+	namespace := string(bytes)
+	return namespace, nil
+}

--- a/internal/common/constants.go
+++ b/internal/common/constants.go
@@ -19,4 +19,6 @@ package common
 const (
 	ManagedByMultiKueueLabel = "kueue.x-k8s.io/multikueue"
 	QueueLabel               = "kueue.x-k8s.io/queue-name"
+	ConfigKey                = "config.yaml"
+	ConfigMapName            = "tekton-kueue-config"
 )

--- a/internal/controller/configmap_controller.go
+++ b/internal/controller/configmap_controller.go
@@ -1,0 +1,57 @@
+package controller
+
+import (
+	"context"
+	"time"
+
+	"github.com/konflux-ci/tekton-kueue/internal/common"
+	v1 "github.com/konflux-ci/tekton-kueue/internal/webhook/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+type ConfigMapReconciler struct {
+	Client client.Client
+	Store  *v1.ConfigStore
+}
+
+func (r *ConfigMapReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	namespace, err := common.GetCurrentNamespace()
+	if err != nil {
+		return err
+	}
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("webhook-config").
+		For(&corev1.ConfigMap{}).
+		WithEventFilter(predicate.NewPredicateFuncs(func(o client.Object) bool {
+			return o.GetName() == common.ConfigMapName && o.GetNamespace() == namespace
+		})).
+		Complete(r)
+}
+
+func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	var cm corev1.ConfigMap
+	logger.Info("Reconciling ConfigMap")
+	if err := r.Client.Get(ctx, req.NamespacedName, &cm); err != nil {
+		logger.Error(err, "unable to fetch ConfigMap", "ConfigMap", req.NamespacedName)
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	raw, ok := cm.Data[common.ConfigKey]
+	if !ok {
+		logger.Info("Key is not present in configmap", "ConfigKey", common.ConfigKey, "ConfigMap", req.NamespacedName)
+		return ctrl.Result{}, nil
+	}
+	if err := r.Store.Update([]byte(raw)); err != nil {
+		logger.Error(err, "unable to update config")
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, err
+	}
+	return ctrl.Result{}, nil
+}

--- a/internal/webhook/v1/config_store.go
+++ b/internal/webhook/v1/config_store.go
@@ -1,0 +1,80 @@
+package v1
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/konflux-ci/tekton-kueue/internal/cel"
+	"github.com/konflux-ci/tekton-kueue/internal/config"
+	tekv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var (
+	logger = ctrl.Log.WithName("config-store")
+)
+
+type ConfigStore struct {
+	mu       sync.RWMutex
+	config   *config.Config
+	mutators []PipelineRunMutator
+}
+
+type PipelineRunMutator interface {
+	Mutate(*tekv1.PipelineRun) error
+}
+
+func (s *ConfigStore) GetConfigAndMutators() (*config.Config, []PipelineRunMutator) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.config, s.mutators
+}
+
+func (s *ConfigStore) Update(rawConfig []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	logger.Info("Updating config", "config", string(rawConfig))
+	cfg, err := parseConfig(rawConfig)
+	if err != nil {
+		RecordReloadFailure()
+		return err
+	}
+	if err := validateConfig(cfg); err != nil {
+		RecordReloadFailure()
+		return err
+	}
+	mutators := []PipelineRunMutator{}
+	if len(cfg.CEL.Expressions) != 0 {
+		programs, err := cel.CompileCELPrograms(cfg.CEL.Expressions)
+		if err != nil {
+			RecordReloadFailure()
+			logger.Error(err, "failed to compile CEL programs")
+			return err
+		}
+		mutators = append(mutators, cel.NewCELMutator(programs))
+	}
+	s.mutators = mutators
+	s.config = &cfg
+	RecordReloadSuccess()
+	logger.Info("Updated config", "config", s.config)
+
+	return nil
+}
+
+func validateConfig(config config.Config) error {
+	if config.QueueName == "" {
+		return errors.New("queue name is not set in the PipelineRunCustomDefaulter")
+	}
+	return nil
+}
+
+func parseConfig(raw []byte) (config.Config, error) {
+	cfg := config.Config{}
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		// Log and keep last-known-good config
+		logger.Error(err, "failed to parse config")
+		return cfg, err
+	}
+	return cfg, nil
+}

--- a/internal/webhook/v1/config_store_test.go
+++ b/internal/webhook/v1/config_store_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Config Store ", func() {
+	Context("Loading Config Store", func() {
+		It("When QueueName is Set", func(ctx context.Context) {
+			configData := "queueName: test-queue"
+			cfgStore := &ConfigStore{}
+			err := cfgStore.Update([]byte(configData))
+			Expect(err).NotTo(HaveOccurred())
+
+			cfg, mutators := cfgStore.GetConfigAndMutators()
+			Expect(mutators).To(BeEmpty())
+			Expect(cfg.QueueName).To(Equal("test-queue"))
+			Expect(cfg.MultiKueueOverride).To(BeFalse())
+
+		})
+		It("When QueueName is Not Set", func(ctx context.Context) {
+			configData := ""
+			cfgStore := &ConfigStore{}
+			err := cfgStore.Update([]byte(configData))
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("Test MultiKueueOverride", func() {
+		It("When MultiKueueOverride is Set", func(ctx context.Context) {
+			configData := "queueName: test-queue\nmultiKueueOverride: true "
+			cfgStore := &ConfigStore{}
+			err := cfgStore.Update([]byte(configData))
+			Expect(err).NotTo(HaveOccurred())
+
+			cfg, mutators := cfgStore.GetConfigAndMutators()
+			Expect(mutators).To(BeEmpty())
+			Expect(cfg.QueueName).To(Equal("test-queue"))
+			Expect(cfg.MultiKueueOverride).To(BeTrue())
+
+		})
+
+		It("When MultiKueueOverride is not Set", func(ctx context.Context) {
+			configData := "queueName: test-queue"
+			cfgStore := &ConfigStore{}
+			err := cfgStore.Update([]byte(configData))
+			Expect(err).NotTo(HaveOccurred())
+
+			cfg, mutators := cfgStore.GetConfigAndMutators()
+			Expect(mutators).To(BeEmpty())
+			Expect(cfg.QueueName).To(Equal("test-queue"))
+			Expect(cfg.MultiKueueOverride).To(BeFalse())
+
+		})
+	})
+
+	Context("Test CEL", func() {
+		configData := "queueName: pipelines-queue\ncel:\n  expressions:\n    - priority(\"tekton-kueue-default\")\n"
+		It("When CEL is set", func(ctx context.Context) {
+			cfgStore := &ConfigStore{}
+			err := cfgStore.Update([]byte(configData))
+			Expect(err).NotTo(HaveOccurred())
+			cfg, mutators := cfgStore.GetConfigAndMutators()
+			Expect(mutators).NotTo(BeEmpty())
+			Expect(cfg.QueueName).To(Equal("pipelines-queue"))
+			Expect(cfg.MultiKueueOverride).To(BeFalse())
+
+		})
+		It("Invalid CEL Configuration", func(ctx context.Context) {
+			configData := "queueName: pipelines-queue\ncel:\n  expressions:\n    - invalid_priority(\"tekton-kueue-default\")\n"
+			cfgStore := &ConfigStore{}
+			err := cfgStore.Update([]byte(configData))
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("Invalid Configuration", func() {
+		configData := "Random Config	 "
+		It("Invalid Tekton-Kueue Configuration", func(ctx context.Context) {
+			cfgStore := &ConfigStore{}
+			err := cfgStore.Update([]byte(configData))
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/internal/webhook/v1/integration/webhook_suite_test.go
+++ b/internal/webhook/v1/integration/webhook_suite_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/konflux-ci/tekton-queue/internal/config"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -42,7 +41,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	v1 "github.com/konflux-ci/tekton-queue/internal/webhook/v1"
+	v1 "github.com/konflux-ci/tekton-kueue/internal/webhook/v1"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -115,9 +114,15 @@ var _ = BeforeSuite(func() {
 		Metrics:        metricsserver.Options{BindAddress: "0"},
 	})
 	Expect(err).NotTo(HaveOccurred())
+	cfgStore := &v1.ConfigStore{}
+	rawConfig := "queueName: pipelines-queue"
 
-	defaulter, err := v1.NewCustomDefaulter(&config.Config{QueueName: "pipelines-queue"}, nil)
+	err = cfgStore.Update([]byte(rawConfig))
 	Expect(err).NotTo(HaveOccurred())
+
+	defaulter, err := v1.NewCustomDefaulter(cfgStore)
+	Expect(err).NotTo(HaveOccurred())
+
 	err = v1.SetupPipelineRunWebhookWithManager(mgr, defaulter)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/internal/webhook/v1/metrics.go
+++ b/internal/webhook/v1/metrics.go
@@ -1,0 +1,42 @@
+package v1
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	// celReloadsTotal tracks the total number of CEL Reloads
+	configReloadTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "tekton_kueue_config_reload_total",
+			Help: "Total number of Config reloads",
+		},
+		[]string{"result"}, // result can be "success" or "failure"
+	)
+
+	// celMutationsTotal tracks the total number of CEL mutation operations
+	configReloadFailureTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "tekton_kueue_config_reload_failure_total",
+			Help: "Total number of Config reload failures",
+		},
+		[]string{"result"}, // result: "success" or "failure"
+	)
+)
+
+func init() {
+	// Register the metrics with controller-runtime's global registry
+	metrics.Registry.MustRegister(configReloadTotal)
+	metrics.Registry.MustRegister(configReloadFailureTotal)
+}
+
+// RecordReloadFailure increments the counter for CEL Reload failures
+func RecordReloadFailure() {
+	configReloadTotal.WithLabelValues("failure").Inc()
+}
+
+// RecordReloadSuccess increments the counter for successful CEL Reloads
+func RecordReloadSuccess() {
+	configReloadTotal.WithLabelValues("success").Inc()
+}

--- a/internal/webhook/v1/pipelinerun_webhook.go
+++ b/internal/webhook/v1/pipelinerun_webhook.go
@@ -18,12 +18,10 @@ package v1
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/konflux-ci/tekton-queue/internal/common"
-	"github.com/konflux-ci/tekton-queue/internal/config"
+	"github.com/konflux-ci/tekton-kueue/internal/common"
 	tekv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -34,8 +32,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
-
-const QueueLabel = "kueue.x-k8s.io/queue-name"
 
 // SetupPipelineRunWebhookWithManager registers the webhook for PipelineRun in the manager.
 func SetupPipelineRunWebhookWithManager(mgr ctrl.Manager, defaulter admission.CustomDefaulter) error {
@@ -73,10 +69,6 @@ func logConstructor(base logr.Logger, req *admission.Request) logr.Logger {
 	return log
 }
 
-type PipelineRunMutator interface {
-	Mutate(*tekv1.PipelineRun) error
-}
-
 // TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
 // +kubebuilder:webhook:path=/mutate-tekton-dev-v1-pipelinerun,mutating=true,failurePolicy=fail,sideEffects=None,groups=tekton.dev,resources=pipelineruns,verbs=create,versions=v1,name=pipelinerun-kueue-defaulter.tekton-kueue.io,admissionReviewVersions=v1
@@ -87,18 +79,12 @@ type PipelineRunMutator interface {
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as it is used only for temporary operations and does not need to be deeply copied.
 type pipelineRunCustomDefaulter struct {
-	config   *config.Config
-	mutators []PipelineRunMutator
+	configStore *ConfigStore
 }
 
-func NewCustomDefaulter(cfg *config.Config, mutators []PipelineRunMutator) (webhook.CustomDefaulter, error) {
-
+func NewCustomDefaulter(configStore *ConfigStore) (webhook.CustomDefaulter, error) {
 	defaulter := &pipelineRunCustomDefaulter{
-		config:   cfg,
-		mutators: mutators,
-	}
-	if err := defaulter.Validate(); err != nil {
-		return nil, err
+		configStore: configStore,
 	}
 	return defaulter, nil
 }
@@ -124,24 +110,18 @@ func (d *pipelineRunCustomDefaulter) Default(ctx context.Context, obj runtime.Ob
 	if plr.Labels == nil {
 		plr.Labels = make(map[string]string)
 	}
+	config, mutators := d.configStore.GetConfigAndMutators()
 	if _, exists := plr.Labels[common.QueueLabel]; !exists {
-		plr.Labels[common.QueueLabel] = d.config.QueueName
+		plr.Labels[common.QueueLabel] = config.QueueName
 	}
-	if d.config.MultiKueueOverride {
+	if config.MultiKueueOverride {
 		plr.Spec.ManagedBy = ptr.To(common.ManagedByMultiKueueLabel)
 	}
-	for _, mutator := range d.mutators {
+	for _, mutator := range mutators {
 		if err := mutator.Mutate(plr); err != nil {
 			return err
 		}
 	}
 
-	return nil
-}
-
-func (d *pipelineRunCustomDefaulter) Validate() error {
-	if d.config.QueueName == "" {
-		return errors.New("queue name is not set in the PipelineRunCustomDefaulter")
-	}
 	return nil
 }

--- a/internal/webhook/v1/pipelinerun_webhook_test.go
+++ b/internal/webhook/v1/pipelinerun_webhook_test.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/konflux-ci/tekton-queue/internal/common"
-	"github.com/konflux-ci/tekton-queue/internal/config"
+	"github.com/konflux-ci/tekton-kueue/internal/common"
+	"github.com/konflux-ci/tekton-kueue/internal/config"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	tektondevv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
@@ -56,8 +56,13 @@ var _ = Describe("PipelineRun Webhook", func() {
 					QueueName:          "test-queue",
 					MultiKueueOverride: true,
 				}
+
+				cfgStore := &ConfigStore{
+					config: cfg,
+				}
+
 				var err error
-				defaulter, err = NewCustomDefaulter(cfg, []PipelineRunMutator{})
+				defaulter, err = NewCustomDefaulter(cfgStore)
 				Expect(err).NotTo(HaveOccurred())
 				err = defaulter.Default(ctx, plr)
 				Expect(err).NotTo(HaveOccurred())
@@ -72,8 +77,11 @@ var _ = Describe("PipelineRun Webhook", func() {
 					QueueName:          "test-queue",
 					MultiKueueOverride: false,
 				}
+				cfgStore := &ConfigStore{
+					config: cfg,
+				}
 				var err error
-				defaulter, err = NewCustomDefaulter(cfg, []PipelineRunMutator{})
+				defaulter, err = NewCustomDefaulter(cfgStore)
 				Expect(err).NotTo(HaveOccurred())
 				err = defaulter.Default(ctx, plr)
 				Expect(err).NotTo(HaveOccurred())
@@ -85,8 +93,11 @@ var _ = Describe("PipelineRun Webhook", func() {
 			cfg := &config.Config{
 				QueueName: "test-queue",
 			}
+			cfgStore := &ConfigStore{
+				config: cfg,
+			}
 			var err error
-			defaulter, err = NewCustomDefaulter(cfg, []PipelineRunMutator{})
+			defaulter, err = NewCustomDefaulter(cfgStore)
 			Expect(err).NotTo(HaveOccurred())
 			err = defaulter.Default(ctx, plr)
 			Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -27,7 +27,7 @@ import (
 
 	"os/exec"
 
-	"github.com/konflux-ci/tekton-queue/test/utils"
+	"github.com/konflux-ci/tekton-kueue/test/utils"
 )
 
 var (


### PR DESCRIPTION
Currently Config is loaded at pod startup time and if there is any change in config then pod must be restarted  for new changes to take effect.

With updated config, if there is any change in config then reconciler loads that immediately and webhook will start using the updated config.

Config map structure is updated to accomodate the multi-cluster feature


```
---
apiVersion: v1
data:
  config.yaml: |
    queueName: pipelines-queue
    cel:
      expressions:
        - priority("tekton-kueue-default")
kind: ConfigMap
metadata:
  labels:
    app.kubernetes.io/part-of: tekton-kueue
  name: tekton-kueue-config
  namespace: tekton-kueue
```

