### PR TITLE
refactor: extract mutate logic to pkg/mutate and add tests

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -87,3 +87,59 @@ func TestControllerFlags_InvalidDuration(t *testing.T) {
 		t.Error("Expected error for invalid duration format, got nil")
 	}
 }
+
+func TestMutateFlags_AddFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected MutateFlags
+	}{
+		{
+			name: "default values",
+			args: []string{},
+			expected: MutateFlags{
+				PipelineRunFile: "",
+				ConfigDir:       "",
+			},
+		},
+		{
+			name: "with pipelinerun file",
+			args: []string{"--pipelinerun-file=/tmp/plr.yaml"},
+			expected: MutateFlags{
+				PipelineRunFile: "/tmp/plr.yaml",
+				ConfigDir:       "",
+			},
+		},
+		{
+			name: "with all flags",
+			args: []string{
+				"--pipelinerun-file=/tmp/plr.yaml",
+				"--config-dir=/tmp/config",
+			},
+			expected: MutateFlags{
+				PipelineRunFile: "/tmp/plr.yaml",
+				ConfigDir:       "/tmp/config",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var flags MutateFlags
+			fs := flag.NewFlagSet("test", flag.ContinueOnError)
+			flags.AddFlags(fs)
+
+			err := fs.Parse(tt.args)
+			if err != nil {
+				t.Fatalf("Failed to parse flags: %v", err)
+			}
+
+			if flags.PipelineRunFile != tt.expected.PipelineRunFile {
+				t.Errorf("PipelineRunFile = %v, want %v", flags.PipelineRunFile, tt.expected.PipelineRunFile)
+			}
+			if flags.ConfigDir != tt.expected.ConfigDir {
+				t.Errorf("ConfigDir = %v, want %v", flags.ConfigDir, tt.expected.ConfigDir)
+			}
+		})
+	}
+}

--- a/pkg/mutate/mutate.go
+++ b/pkg/mutate/mutate.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutate
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+
+	webhookv1 "github.com/konflux-ci/tekton-kueue/internal/webhook/v1"
+	tekv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"sigs.k8s.io/yaml"
+)
+
+// MutatePipelineRun reads a PipelineRun from a file, applies mutations based on the config,
+// and returns the mutated PipelineRun as YAML bytes.
+func MutatePipelineRun(pipelineRunFile, configDir string) ([]byte, error) {
+	// Validate inputs
+	if pipelineRunFile == "" {
+		return nil, fmt.Errorf("pipelineRunFile cannot be empty")
+	}
+	if configDir == "" {
+		return nil, fmt.Errorf("configDir cannot be empty")
+	}
+
+	// Load PipelineRun from file
+	pipelineRunData, err := os.ReadFile(pipelineRunFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read PipelineRun file %q: %w", pipelineRunFile, err)
+	}
+
+	// Parse PipelineRun YAML
+	var pipelineRun tekv1.PipelineRun
+	if err := yaml.Unmarshal(pipelineRunData, &pipelineRun); err != nil {
+		return nil, fmt.Errorf("failed to parse PipelineRun YAML: %w", err)
+	}
+
+	// Load config and create defaulter
+	cfgStore, err := LoadDefaulter(configDir)
+	if err != nil {
+		return nil, err
+	}
+
+	defaulter, err := webhookv1.NewCustomDefaulter(cfgStore)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create custom defaulter: %w", err)
+	}
+
+	// Apply mutation
+	ctx := context.Background()
+	if err := defaulter.Default(ctx, &pipelineRun); err != nil {
+		return nil, fmt.Errorf("failed to apply mutation to PipelineRun: %w", err)
+	}
+
+	// Marshal the mutated PipelineRun back to YAML
+	mutatedData, err := yaml.Marshal(&pipelineRun)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal mutated PipelineRun to YAML: %w", err)
+	}
+
+	return mutatedData, nil
+}
+
+// LoadDefaulter loads the webhook configuration and returns a ConfigStore.
+func LoadDefaulter(configDir string) (*webhookv1.ConfigStore, error) {
+	if configDir == "" {
+		return nil, fmt.Errorf("configDir cannot be empty")
+	}
+
+	configPath := path.Join(configDir, "config.yaml")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file %q: %w", configPath, err)
+	}
+
+	cfgStore := &webhookv1.ConfigStore{}
+	if err := cfgStore.Update(data); err != nil {
+		return nil, fmt.Errorf("failed to update config: %w", err)
+	}
+
+	return cfgStore, nil
+}

--- a/pkg/mutate/mutate_test.go
+++ b/pkg/mutate/mutate_test.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/konflux-ci/tekton-kueue/pkg/common"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	tekv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"sigs.k8s.io/yaml"
+)
+
+func TestMutate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Mutate Suite")
+}
+
+var _ = Describe("MutatePipelineRun", func() {
+	var (
+		tmpDir string
+	)
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "mutate-test")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(tmpDir)).To(Succeed())
+	})
+
+	Context("with valid PipelineRun", func() {
+		It("should mutate a PipelineRun with pipelineRef", func() {
+			// Write config file
+			configPath := filepath.Join(tmpDir, "config.yaml")
+			Expect(os.WriteFile(configPath, []byte(`queueName: "test-queue"`), 0644)).To(Succeed())
+
+			// Write PipelineRun file
+			plrContent := `apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: test-pipelinerun
+spec:
+  pipelineRef:
+    name: my-pipeline
+`
+			plrPath := filepath.Join(tmpDir, "pipelinerun.yaml")
+			Expect(os.WriteFile(plrPath, []byte(plrContent), 0644)).To(Succeed())
+
+			// Call MutatePipelineRun
+			mutatedData, err := MutatePipelineRun(plrPath, tmpDir)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Parse and validate
+			var pipelineRun tekv1.PipelineRun
+			Expect(yaml.Unmarshal(mutatedData, &pipelineRun)).To(Succeed())
+			Expect(pipelineRun.Labels[common.QueueLabel]).To(Equal("test-queue"))
+			Expect(pipelineRun.Spec.Status).To(Equal(tekv1.PipelineRunSpecStatus(tekv1.PipelineRunSpecStatusPending)))
+		})
+
+		It("should mutate a PipelineRun with pipelineSpec", func() {
+			// Write config file
+			configPath := filepath.Join(tmpDir, "config.yaml")
+			Expect(os.WriteFile(configPath, []byte(`queueName: "my-queue"`), 0644)).To(Succeed())
+
+			// Write PipelineRun file
+			plrContent := `apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: test-pipelinerun
+spec:
+  pipelineSpec:
+    tasks:
+      - name: echo
+        taskSpec:
+          steps:
+            - name: echo
+              image: alpine:latest
+              script: echo hello
+`
+			plrPath := filepath.Join(tmpDir, "pipelinerun.yaml")
+			Expect(os.WriteFile(plrPath, []byte(plrContent), 0644)).To(Succeed())
+
+			// Call MutatePipelineRun
+			mutatedData, err := MutatePipelineRun(plrPath, tmpDir)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Parse and validate
+			var pipelineRun tekv1.PipelineRun
+			Expect(yaml.Unmarshal(mutatedData, &pipelineRun)).To(Succeed())
+			Expect(pipelineRun.Labels[common.QueueLabel]).To(Equal("my-queue"))
+			Expect(pipelineRun.Spec.Status).To(Equal(tekv1.PipelineRunSpecStatus(tekv1.PipelineRunSpecStatusPending)))
+		})
+	})
+
+	Context("with invalid PipelineRun", func() {
+		It("should reject a PipelineRun with neither pipelineRef nor pipelineSpec", func() {
+			// Write config file
+			configPath := filepath.Join(tmpDir, "config.yaml")
+			Expect(os.WriteFile(configPath, []byte(`queueName: "test-queue"`), 0644)).To(Succeed())
+
+			// Write invalid PipelineRun file
+			plrContent := `apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: test-pipelinerun
+spec: {}
+`
+			plrPath := filepath.Join(tmpDir, "pipelinerun.yaml")
+			Expect(os.WriteFile(plrPath, []byte(plrContent), 0644)).To(Succeed())
+
+			// Call MutatePipelineRun - should fail
+			_, err := MutatePipelineRun(plrPath, tmpDir)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("with invalid inputs", func() {
+		It("should reject empty pipelineRunFile", func() {
+			_, err := MutatePipelineRun("", "/tmp")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should reject empty configDir", func() {
+			_, err := MutatePipelineRun("/tmp/plr.yaml", "")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should reject non-existent pipelinerun file", func() {
+			// Write config file
+			configPath := filepath.Join(tmpDir, "config.yaml")
+			Expect(os.WriteFile(configPath, []byte(`queueName: "test-queue"`), 0644)).To(Succeed())
+
+			_, err := MutatePipelineRun("/non/existent/file.yaml", tmpDir)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should reject non-existent config dir", func() {
+			// Write PipelineRun file
+			plrContent := `apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: test
+spec:
+  pipelineRef:
+    name: my-pipeline
+`
+			plrPath := filepath.Join(tmpDir, "pipelinerun.yaml")
+			Expect(os.WriteFile(plrPath, []byte(plrContent), 0644)).To(Succeed())
+
+			_, err := MutatePipelineRun(plrPath, "/non/existent/config")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})
+
+var _ = Describe("LoadDefaulter", func() {
+	var (
+		tmpDir string
+	)
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "mutate-test")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(tmpDir)).To(Succeed())
+	})
+
+	It("should load a valid config", func() {
+		configPath := filepath.Join(tmpDir, "config.yaml")
+		Expect(os.WriteFile(configPath, []byte(`queueName: "test-queue"`), 0644)).To(Succeed())
+
+		cfgStore, err := LoadDefaulter(tmpDir)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfgStore).NotTo(BeNil())
+	})
+
+	It("should reject empty configDir", func() {
+		_, err := LoadDefaulter("")
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should reject missing config file", func() {
+		_, err := LoadDefaulter(tmpDir)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should reject invalid config", func() {
+		// Write invalid config (missing queueName)
+		configPath := filepath.Join(tmpDir, "config.yaml")
+		Expect(os.WriteFile(configPath, []byte(`invalid: config`), 0644)).To(Succeed())
+
+		_, err := LoadDefaulter(tmpDir)
+		Expect(err).To(HaveOccurred())
+	})
+})


### PR DESCRIPTION
- Move PipelineRun mutation logic from cmd/main.go to pkg/mutate package
- Use sigs.k8s.io/yaml instead of gopkg.in/yaml.v3 for proper Kubernetes resource unmarshaling
- Add comprehensive tests for MutatePipelineRun and LoadDefaulter using Ginkgo/Gomega
- Add webhook tests for validating PipelineRuns with pipelineRef, pipelineSpec, and invalid specs (negative case)
- Remove unused customDefaulter function and imports from cmd/main.go

Assisted-By: Cursor