### PR TITLE
fix: call SetDefaults before Validate to fix PipelineRun rejection

### DIFF
--- a/internal/webhook/v1/pipelinerun_webhook.go
+++ b/internal/webhook/v1/pipelinerun_webhook.go
@@ -97,10 +97,11 @@ func (d *pipelineRunCustomDefaulter) Default(ctx context.Context, obj runtime.Ob
 		return k8serrors.NewBadRequest(fmt.Sprintf("expected an PipelineRun object but got %T", obj))
 	}
 
-	// Attempt to catch bad pipelineruns prior to processing so we can catch
+	// Set default values and attempt to catch bad pipelineruns prior to processing so we can catch
 	// errors ourselves and handle them appropriately.  Only validate the spec
 	// field, since we might be getting a pipelinerun with a generated name, which
 	// the top-level Validate() method will reject
+	plr.Spec.SetDefaults(ctx)
 	err := plr.Spec.Validate(ctx)
 	if err != nil {
 		return k8serrors.NewBadRequest(err.Error())


### PR DESCRIPTION
PipelineRuns with embedded pipelineSpec containing parameters without explicit 'type' fields were incorrectly rejected with:
  "invalid value: : params.enable-cache-proxy.type"

The issue was that Tekton's Validate() requires the type field to be set, but parameters without an explicit type should default to "string".

The fix calls plr.Spec.SetDefaults(ctx) before Validate() to ensure default values are populated, allowing valid PipelineRuns to pass validation.

Also adds a test case reproducing this scenario with a parameter that has no explicit type field.

Assisted-By: Cursor