### PR TITLE
add ldflags to reduce binary size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY internal/ internal/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -trimpath -ldflags="-s -w" -o manager cmd/main.go
 
 
 FROM registry.access.redhat.com/ubi9-micro@sha256:f5c5213d2969b7b11a6666fc4b849d56b48d9d7979b60a37bb853dff0255c14b


### PR DESCRIPTION
This change introduces some build flags to strip debug information from the containerized binary.

With this change the image size drops from 103MiB to 78MiB.

* `-ldflags`
  * `-s`: Omit the symbol table and debug information.
	Implies the -w flag, which can be negated with -w=0.
  * `-w` Omit the DWARF symbol table.
* `-trimpath`: remove all file system paths from the resulting executable.
	Instead of absolute file system paths, the recorded file names
	will begin either a module path@version (when using modules),
	or a plain import path (when using the standard library, or GOPATH).

References:
* https://pkg.go.dev/cmd/link
* https://pkg.go.dev/cmd/go#hdr-Compile_packages_and_dependencies

Signed-off-by: Francesco Ilario <filario@redhat.com>
