### PR TITLE
simplify e2e tests

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -33,10 +33,8 @@ jobs:
       - name: Running Test e2e
         env:
           KIND_EXPERIMENTAL_PROVIDER: podman
-          IMG: konflux-ci.dev/tekton-kueue:v0.0.1
         run: |
-          go mod tidy
-          make load-image "IMG=$IMG"
+          make load-image
           podman exec kind-control-plane crictl images
           make kueue
           make tekton

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-IMG ?= tekton-kueue:latest
+IMG ?= localhost/tekton-kueue:local
 KIND_CLUSTER ?= kind
 RELEASE_DIR ?= release
 VERSION ?= nightly
@@ -79,7 +79,7 @@ test-e2e: manifests generate fmt vet ## Run the e2e tests. Expected an isolated 
 		echo "No Kind cluster is running. Please start a Kind cluster before running the e2e tests."; \
 		exit 1; \
 	}
-	go test ./test/e2e/ -v -ginkgo.v
+	IMG=${IMG} go test ./test/e2e/ -v -ginkgo.v
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter


### PR DESCRIPTION
With this changes, to execute locally e2e-tests it's only required to run

```
kind create cluster
make load-image kueue tekton
make test-e2e
```

Signed-off-by: Francesco Ilario <filario@redhat.com>
