### PR TITLE
Add dependency PR auto-triage

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,9 @@
   "enabledManagers": [
     "tekton",
     "dockerfile",
-    "rpm-lockfile"
+    "rpm-lockfile",
+    "gomod",
+    "github-actions"
   ],
   "addLabels": [
     "approved",
@@ -16,10 +18,91 @@
   ],
   "ignorePaths": ["upstream/**"],
   "autoApprove": true,
+  "gomod": {
+    "postUpdateOptions": [
+      "gomodTidy"
+    ]
+  },
   "packageRules": [
     {
-      "matchPackageNames": ["*"],
-      "automerge": true
+      "description": "Group and auto-merge go module patch bumps together",
+      "groupName": "go-modules patch",
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["patch", "digest"],
+      "automerge": true,
+      "addLabels": ["auto-merged"]
+    },
+    {
+      "description": "Group go module minor bumps together",
+      "groupName": "go-modules minor",
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["minor"]
+    },
+    {
+      "description": "Individual PRs for go module major bumps (no groupName = one PR per package)",
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["major"]
+    },
+    {
+      "description": "Group Kubernetes and controller-runtime updates together",
+      "groupName": "go-modules k8s",
+      "matchManagers": ["gomod"],
+      "matchPackagePatterns": ["^k8s\\.io/"],
+      "matchPackageNames": ["sigs.k8s.io/controller-runtime"],
+      "matchUpdateTypes": ["minor", "major", "digest"]
+    },
+    {
+      "description": "Label patch version bumps",
+      "matchUpdateTypes": ["patch", "digest"],
+      "addLabels": ["semver/patch"]
+    },
+    {
+      "description": "Label minor version bumps",
+      "matchUpdateTypes": ["minor"],
+      "addLabels": ["semver/minor"]
+    },
+    {
+      "description": "Label major version bumps",
+      "matchUpdateTypes": ["major"],
+      "addLabels": ["semver/major"]
+    },
+    {
+      "description": "Label direct dependencies",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["dependencies"],
+      "addLabels": ["dependency/direct"]
+    },
+    {
+      "description": "Label transitive (indirect) dependencies",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "addLabels": ["dependency/transitive"]
+    },
+    {
+      "description": "Prioritize Konflux tekton task reference updates",
+      "matchManagers": ["tekton"],
+      "prPriority": 10,
+      "automerge": true,
+      "addLabels": ["auto-merged"]
+    },
+    {
+      "description": "Auto-merge dockerfile updates (except Go toolchain)",
+      "matchManagers": ["dockerfile"],
+      "excludePackagePatterns": ["go-toolset"],
+      "automerge": true,
+      "addLabels": ["auto-merged"]
+    },
+    {
+      "description": "Go toolchain updates require manual review",
+      "matchManagers": ["dockerfile"],
+      "matchPackagePatterns": ["go-toolset"],
+      "automerge": false
+    },
+    {
+      "description": "Auto-merge rpm-lockfile updates",
+      "matchManagers": ["rpm-lockfile"],
+      "automerge": true,
+      "addLabels": ["auto-merged"]
     }
   ]
 }

--- a/.github/workflows/dep-imports.yaml
+++ b/.github/workflows/dep-imports.yaml
@@ -1,0 +1,97 @@
+name: Dependency Import Usage
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  import-usage:
+    name: Post import usage for direct dependencies
+    if: >-
+      github.event.label.name == 'dependency/direct' &&
+      (
+        github.event.pull_request.user.login == 'renovate[bot]' ||
+        github.event.pull_request.user.login == 'red-hat-konflux[bot]'
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Extract updated package names from PR body
+        id: packages
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # Extract Go module package names from the Renovate PR body table.
+          # Renovate lists packages in markdown table rows in two formats:
+          #   Bare:   | github.com/foo/bar | 1.0.0 -> 1.0.1 | ... |
+          #   Linked: | [github.com/foo/bar](https://...) | `v1.0.0` -> `v1.0.1` | ... |
+          # Strip markdown links first, then extract module paths.
+          PACKAGES=$(echo "${PR_BODY}" \
+            | sed 's/\[\([^]]*\)\]([^)]*)/\1/g' \
+            | grep -oP '(?<=\| )[a-zA-Z0-9._-]+\.[a-zA-Z]{2,}/[a-zA-Z0-9._/-]+(?= \|)' \
+            | sort -u \
+            || true)
+
+          if [[ -z "${PACKAGES}" ]]; then
+            # Fallback: try to extract from PR title (e.g., "chore(deps): update module github.com/foo/bar to v1.2.3")
+            PACKAGES=$(echo "${{ github.event.pull_request.title }}" \
+              | grep -oP '[a-zA-Z0-9._-]+\.[a-zA-Z]{2,}/[a-zA-Z0-9._/-]+' \
+              || true)
+          fi
+
+          if [[ -z "${PACKAGES}" ]]; then
+            echo "No packages found in PR body or title"
+            echo "packages=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Store as newline-separated list
+          echo "packages<<EOF" >> "$GITHUB_OUTPUT"
+          echo "${PACKAGES}" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Find import usage
+        if: steps.packages.outputs.packages != ''
+        id: imports
+        run: |
+          COMMENT="## Import Usage for Direct Dependencies\n\n"
+          FOUND_ANY=false
+
+          while IFS= read -r pkg; do
+            [[ -z "${pkg}" ]] && continue
+            COMMENT+="### \`${pkg}\`\n\n"
+
+            OUTPUT=$(./hack/dep-imports.sh "${pkg}" 2>&1) || true
+            if echo "${OUTPUT}" | grep -q "No imports found"; then
+              COMMENT+="> No direct imports found in source files.\n\n"
+            else
+              FOUND_ANY=true
+              COMMENT+="\`\`\`\n${OUTPUT}\n\`\`\`\n\n"
+            fi
+          done <<< "${{ steps.packages.outputs.packages }}"
+
+          # Write comment body to a file to avoid escaping issues
+          echo -e "${COMMENT}" > /tmp/pr-comment.md
+
+      - name: Post PR comment
+        if: steps.packages.outputs.packages != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Delete previous import-usage comment if it exists (avoid duplicates)
+          EXISTING=$(gh api --paginate "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            --jq '.[] | select(.body | startswith("## Import Usage")) | .id' || true)
+
+          for id in ${EXISTING}; do
+            gh api -X DELETE "repos/${{ github.repository }}/issues/comments/${id}" || true
+          done
+
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --body-file /tmp/pr-comment.md

--- a/.github/workflows/dep-semver-label.yaml
+++ b/.github/workflows/dep-semver-label.yaml
@@ -1,0 +1,77 @@
+name: Dependency Semver Labels (fallback)
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  semver-label:
+    name: Ensure semver labels on dependency PRs
+    if: >-
+      github.event.pull_request.user.login == 'renovate[bot]' ||
+      github.event.pull_request.user.login == 'red-hat-konflux[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Check for existing semver labels
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LABELS=$(gh pr view "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --json labels --jq '.labels[].name' || true)
+
+          if echo "${LABELS}" | grep -q "^semver/"; then
+            echo "Semver label already present, skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No semver label found, will detect and apply"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout code
+        if: steps.check.outputs.skip != 'true'
+        uses: actions/checkout@v4
+
+      - name: Detect and apply semver label
+        if: steps.check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          echo "${PR_BODY}" > /tmp/pr-body.md
+
+          BUMP_TYPE=$(./hack/detect-semver-bump.sh /tmp/pr-body.md "${{ github.event.pull_request.title }}")
+          echo "Detected bump type: ${BUMP_TYPE}"
+
+          # Map digest to patch for labeling purposes
+          LABEL_TYPE="${BUMP_TYPE}"
+          if [[ "${LABEL_TYPE}" == "digest" ]]; then
+            LABEL_TYPE="patch"
+          fi
+
+          if [[ "${LABEL_TYPE}" == "unknown" ]]; then
+            echo "Could not determine semver bump type, skipping label"
+            exit 0
+          fi
+
+          # Create the label if it doesn't exist
+          case "${LABEL_TYPE}" in
+            patch) COLOR="0e8a16" ;;  # green
+            minor) COLOR="fbca04" ;;  # yellow
+            major) COLOR="e11d48" ;;  # red
+          esac
+
+          gh label create "semver/${LABEL_TYPE}" --repo "${{ github.repository }}" \
+            --color "${COLOR}" --description "Semver ${LABEL_TYPE} version bump" \
+            --force 2>/dev/null || true
+
+          gh pr edit "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --add-label "semver/${LABEL_TYPE}"
+
+          echo "Applied label: semver/${LABEL_TYPE}"

--- a/docs/dependency-policy.md
+++ b/docs/dependency-policy.md
@@ -1,0 +1,85 @@
+# Dependency Update Triage Policy
+
+This document describes how dependency update PRs (from Renovate/Mintmaker) are classified, labeled, and triaged in this repository.
+
+## Classification
+
+### Direct vs. Transitive
+
+Dependencies are classified using Renovate's native `matchDepTypes`:
+
+- **Direct** (`dependency/direct` label): Packages listed in `go.mod` without `// indirect`. These are imported directly by our source code.
+- **Transitive** (`dependency/transitive` label): Packages listed in `go.mod` with `// indirect`. These are pulled in as dependencies of our direct dependencies.
+
+### Semver Bump Type
+
+Every dependency PR is labeled with the semver bump type:
+
+- `semver/patch` — Patch or digest updates (e.g., 1.2.3 → 1.2.4). Bug fixes only, no new features or breaking changes per semver contract.
+- `semver/minor` — Minor updates (e.g., 1.2.0 → 1.3.0). New features, backwards-compatible.
+- `semver/major` — Major updates (e.g., 1.0.0 → 2.0.0). May contain breaking changes.
+
+### Semver Label Fallback
+
+Semver labels are primarily applied by Renovate via `packageRules`. As a fallback, a GitHub Action workflow (`.github/workflows/dep-semver-label.yaml`) detects the bump type from the PR body/title and applies the label if Renovate hasn't. This handles edge cases like two-component docker tags (`v9.5` → `v9.7`) and digest-only updates.
+
+## Auto-merge Rules
+
+| Update Type | Direct | Transitive | Action |
+|-------------|--------|------------|--------|
+| Patch/digest | Auto-merge | Auto-merge | Merged automatically when CI passes |
+| Minor | Manual review | Manual review | Requires human approval |
+| Major | Manual review | Manual review | Requires human approval |
+| Konflux references (Tekton tasks) | N/A | N/A | Auto-merge when CI passes |
+| Dockerfile updates | N/A | N/A | Auto-merge when CI passes |
+| Go toolchain (go-toolset) | N/A | N/A | **Manual review required** |
+| RPM lockfile updates | N/A | N/A | Auto-merge when CI passes |
+
+Auto-merge uses GitHub's platform auto-merge (`platformAutomerge`), which requires all required status checks to pass before merging.
+
+### Rationale
+
+- **Patch bumps** are low-risk by semver convention (bug fixes only). Combined with CI validation, auto-merging reduces review burden without meaningful risk.
+- **Minor/major bumps** may introduce new behavior or breaking changes and benefit from human review.
+- **Konflux reference updates** are digest-only updates to build pipeline task references — they are validated by the Tekton pipeline CI.
+- **Go toolchain updates** (`go-toolset` image) are excluded from auto-merge because they frequently require coordinated changes to build infrastructure (Tekton task images, Dockerfile base images) and have historically caused CI failures.
+
+## PR Grouping
+
+Go module updates are grouped to reduce PR volume:
+
+- `go-modules patch` — All patch/digest bumps in one PR
+- `go-modules minor` — All minor bumps in one PR
+- Major bumps — Individual PRs per package (ungrouped)
+- `go-modules k8s` — Kubernetes-related packages (`k8s.io/*`, `sigs.k8s.io/controller-runtime`) grouped together for minor/major/digest updates
+
+## Import Usage Comments
+
+For PRs updating direct dependencies, a GitHub Action posts a comment listing which source files import the package. This helps reviewers assess the impact of non-auto-merged updates (minor/major bumps).
+
+## Override Procedure
+
+To exclude a specific package from auto-merge, add a `packageRules` entry in `renovate.json`:
+
+```json
+{
+  "description": "Require manual review for package-name",
+  "matchPackageNames": ["github.com/example/package-name"],
+  "automerge": false
+}
+```
+
+Place this rule **after** the auto-merge rules so it takes precedence.
+
+## Rollback Procedure
+
+If an auto-merged dependency update causes a regression:
+
+1. **Revert the PR**: Create a revert PR for the problematic merge.
+2. **Disable auto-merge temporarily** (if needed): Set `automerge: false` on the relevant `packageRules` in `renovate.json`. This is a single-line change.
+3. **Investigate**: Determine if the issue is in the dependency or in our usage of it.
+4. **Re-enable**: Once resolved, remove the `automerge: false` override.
+
+## Configuration
+
+All policies are configured in [`.github/renovate.json`](../.github/renovate.json). Mintmaker's base config (`inheritConfig: true`) is merged with this repo-level config.

--- a/hack/dep-imports.sh
+++ b/hack/dep-imports.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# dep-imports.sh — List source files that import a given Go package.
+# Usage: ./hack/dep-imports.sh <package-name>
+# Example: ./hack/dep-imports.sh github.com/onsi/gomega
+#
+# Exits 0 if imports found, 1 if no imports found, 2 on usage error.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <package-name>" >&2
+    exit 2
+fi
+
+PACKAGE="$1"
+ROOT="${2:-.}"
+
+# Search Go source files for import statements matching the package.
+# Uses fixed-string matching (-F) because Go module paths contain dots
+# that would be regex metacharacters.
+MATCHES=$(grep -rnF --include='*.go' "\"${PACKAGE}" "${ROOT}" |
+    grep -v '_test.go' |
+    grep -v '/vendor/' |
+    grep -v '/hack/' ||
+    true)
+
+if [[ ! "${MATCHES}" ]]; then
+    echo "No imports found for package: ${PACKAGE}"
+    exit 1
+fi
+
+echo "Files importing ${PACKAGE}:"
+echo "${MATCHES}"
+exit 0

--- a/hack/detect-semver-bump.sh
+++ b/hack/detect-semver-bump.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# detect-semver-bump.sh — Detect the semver bump type from a Renovate PR.
+# Usage: ./hack/detect-semver-bump.sh <pr-body-file> [pr-title]
+#
+# Analyzes version changes in the PR body/title and outputs one of:
+#   major, minor, patch, digest, unknown
+#
+# Exits 0 on success, 2 on usage error.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <pr-body-file> [pr-title]" >&2
+    exit 2
+fi
+
+PR_BODY_FILE="$1"
+PR_TITLE="${2:-}"
+
+if [[ ! -f "${PR_BODY_FILE}" ]]; then
+    echo "Error: PR body file not found: ${PR_BODY_FILE}" >&2
+    exit 2
+fi
+
+# Combine body and title for analysis
+COMBINED=$(cat "${PR_BODY_FILE}")
+if [[ -n "${PR_TITLE}" ]]; then
+    COMBINED="${PR_TITLE}\n${COMBINED}"
+fi
+
+echo -e "${COMBINED}" | python3 -c '
+import sys, re
+
+text = sys.stdin.read()
+
+# Try three-component semver first: v1.5.0 -> v1.9.0
+version_pairs_3 = re.findall(
+    r"`?v?(\d+)\.(\d+)\.(\d+)[^`]*`?\s*->\s*`?v?(\d+)\.(\d+)\.(\d+)",
+    text
+)
+
+# Also try two-component versions (e.g., docker tags: v9.5-build -> v9.7-build)
+version_pairs_2 = re.findall(
+    r"`?v?(\d+)\.(\d+)(?:[-.][^`\s]*)?`?\s*->\s*`?v?(\d+)\.(\d+)(?:[-.][^`\s]*)?`?",
+    text
+)
+
+if not version_pairs_3 and not version_pairs_2:
+    # Check for digest updates: `054e65f` -> `716be56`
+    if re.search(r"`[0-9a-f]{7,}`\s*->\s*`[0-9a-f]{7,}`", text):
+        print("digest")
+    else:
+        print("unknown")
+    sys.exit(0)
+
+# Determine the highest bump across all version pairs.
+highest = "patch"
+
+for old_maj, old_min, old_pat, new_maj, new_min, new_pat in version_pairs_3:
+    if int(new_maj) != int(old_maj):
+        highest = "major"
+        break
+    elif int(new_min) != int(old_min):
+        highest = "minor"
+
+if highest != "major":
+    for old_maj, old_min, new_maj, new_min in version_pairs_2:
+        if int(new_maj) != int(old_maj):
+            highest = "major"
+            break
+        elif int(new_min) != int(old_min):
+            highest = "minor"
+
+print(highest)
+'


### PR DESCRIPTION
Reduce manual review burden for Renovate/Mintmaker dependency PRs by adding automated classification and risk-based triage policies.

Engineers currently review all dependency PRs with the same level of scrutiny regardless of risk. This change enables the IC rotation to focus on PRs that actually need human judgment by:

- Classifying dependencies as direct or transitive via Renovate labels
- Adding semver bump type labels (patch/minor/major)
- Splitting patch and minor bumps into separate PR groups so low-risk patches don't get blocked by minor updates in the same PR
- Auto-merging gomod patch bumps when CI passes; gomod minor/major bumps still require manual review
- Auto-merging all build infra updates (tekton, dockerfile, rpm-lockfile) regardless of semver level when CI passes
- Adding a GitHub Action that posts import-usage comments on direct dependency PRs to help reviewers assess impact
- Labeling auto-merged PRs with 'auto-merged' to distinguish them from human-reviewed changes
