### PR TITLE
fix: use explicit JSON patches to prevent zero-value field leaks in webhook

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -45,6 +45,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/konflux-ci/tekton-kueue/internal/controller"
 	webhookv1 "github.com/konflux-ci/tekton-kueue/internal/webhook/v1"
@@ -288,14 +289,11 @@ func runWebhook(args []string) {
 		os.Exit(1)
 	}
 	cfgStore := &webhookv1.ConfigStore{}
-	customDefaulter, err := webhookv1.NewCustomDefaulter(cfgStore)
-	if err != nil {
-		setupLog.Error(err, "unable to create custom defaulter")
-		os.Exit(1)
-	}
+	decoder := admission.NewDecoder(scheme)
+	handler := webhookv1.NewWebhookHandler(cfgStore, decoder)
 	err = webhookv1.SetupPipelineRunWebhookWithManager(
 		mgr,
-		customDefaulter,
+		handler,
 	)
 	if err != nil {
 		setupLog.Error(err, "Failed to setup the webhook")

--- a/internal/webhook/v1/integration/webhook_suite_test.go
+++ b/internal/webhook/v1/integration/webhook_suite_test.go
@@ -31,6 +31,7 @@ import (
 
 	tektondevv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	admissionv1 "k8s.io/api/admission/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -120,10 +121,9 @@ var _ = BeforeSuite(func() {
 	err = cfgStore.Update([]byte(rawConfig))
 	Expect(err).NotTo(HaveOccurred())
 
-	defaulter, err := v1.NewCustomDefaulter(cfgStore)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = v1.SetupPipelineRunWebhookWithManager(mgr, defaulter)
+	decoder := admission.NewDecoder(mgr.GetScheme())
+	handler := v1.NewWebhookHandler(cfgStore, decoder)
+	err = v1.SetupPipelineRunWebhookWithManager(mgr, handler)
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:webhook

--- a/internal/webhook/v1/pipelinerun_webhook.go
+++ b/internal/webhook/v1/pipelinerun_webhook.go
@@ -20,84 +20,186 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"strings"
 
-	"github.com/go-logr/logr"
 	"github.com/konflux-ci/tekton-kueue/internal/cel"
 	"github.com/konflux-ci/tekton-kueue/pkg/common"
 	tekv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/klog/v2"
-	"k8s.io/utils/ptr"
+	"gomodules.xyz/jsonpatch/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-// SetupPipelineRunWebhookWithManager registers the webhook for PipelineRun in the manager.
-func SetupPipelineRunWebhookWithManager(mgr ctrl.Manager, defaulter admission.CustomDefaulter) error {
-	return ctrl.NewWebhookManagedBy(mgr).For(&tekv1.PipelineRun{}).
-		WithDefaulter(defaulter).
-		WithLogConstructor(logConstructor).
-		Complete()
+// +kubebuilder:webhook:path=/mutate-tekton-dev-v1-pipelinerun,mutating=true,failurePolicy=fail,sideEffects=None,groups=tekton.dev,resources=pipelineruns,verbs=create,versions=v1,name=pipelinerun-kueue-defaulter.tekton-kueue.io,admissionReviewVersions=v1
+
+// PipelineRunWebhookHandler handles PipelineRun admission requests using
+// explicit JSON patches. This avoids controller-runtime's CustomDefaulter
+// pattern which serializes the full Go struct and can leak zero-value fields
+// into the patch, interfering with downstream webhook defaulting.
+//
+// See: https://github.com/tektoncd/pipeline/issues/9647
+type PipelineRunWebhookHandler struct {
+	configStore *ConfigStore
+	decoder     admission.Decoder
 }
 
-func logConstructor(base logr.Logger, req *admission.Request) logr.Logger {
-	gvk := (&tekv1.PipelineRun{}).GetGroupVersionKind()
-	log := base.WithValues(
-		"webhookGroup", gvk.Group,
-		"webhookKind", gvk.Kind,
-	)
-	if req != nil {
-		log = log.WithValues(
-			"webhookGroup", tekv1.SchemeGroupVersion.Group,
-			"webhookKind", gvk.Kind,
-			gvk.Kind, klog.KRef(req.Namespace, req.Name),
-			"namespace", req.Namespace,
-			"name", req.Name,
-			"resource", req.Resource,
-			"user", req.UserInfo.Username,
-			"requestID", req.UID,
-		)
+func NewWebhookHandler(configStore *ConfigStore, decoder admission.Decoder) *PipelineRunWebhookHandler {
+	return &PipelineRunWebhookHandler{
+		configStore: configStore,
+		decoder:     decoder,
+	}
+}
 
-		if a, err := meta.Accessor(req.Object); err == nil {
-			if a.GetName() == "" {
-				// add the generate name only if the name is unset
-				return log.WithValues("generateName", a.GetGenerateName())
+// Handle builds explicit JSON patches for only the fields we intend to modify.
+// No struct round-tripping means no zero-value field leaks.
+func (h *PipelineRunWebhookHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	plr := &tekv1.PipelineRun{}
+	if err := h.decoder.Decode(req, plr); err != nil {
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("expected a PipelineRun object: %w", err))
+	}
+
+	config, mutators := h.configStore.GetConfigAndMutators()
+
+	var patches []jsonpatch.JsonPatchOperation
+
+	// 1. Set spec.status = PipelineRunPending
+	patches = append(patches, jsonpatch.JsonPatchOperation{
+		Operation: "add",
+		Path:      "/spec/status",
+		Value:     string(tekv1.PipelineRunSpecStatusPending),
+	})
+
+	// 2. Add queue label
+	if plr.Labels == nil {
+		patches = append(patches, jsonpatch.JsonPatchOperation{
+			Operation: "add",
+			Path:      "/metadata/labels",
+			Value:     map[string]string{common.QueueLabel: config.QueueName},
+		})
+	} else if _, exists := plr.Labels[common.QueueLabel]; !exists {
+		patches = append(patches, jsonpatch.JsonPatchOperation{
+			Operation: "add",
+			Path:      "/metadata/labels/" + escapeJSONPointer(common.QueueLabel),
+			Value:     config.QueueName,
+		})
+	}
+
+	// 3. Set managedBy if multiKueueOverride is enabled
+	if config.MultiKueueOverride {
+		patches = append(patches, jsonpatch.JsonPatchOperation{
+			Operation: "add",
+			Path:      "/spec/managedBy",
+			Value:     common.ManagedByMultiKueueLabel,
+		})
+	}
+
+	// 4. Apply CEL mutations. CEL only modifies labels, annotations, and
+	//    resource annotations — all metadata, no spec fields. We apply them
+	//    to the decoded struct then diff only the metadata to build patches.
+	if len(mutators) > 0 {
+		// Deep copy so CEL mutations don't affect our original
+		plrForCEL := plr.DeepCopy()
+		for _, mutator := range mutators {
+			if err := mutator.Mutate(plrForCEL); err != nil {
+				var validationErr *cel.ValidationError
+				if errors.As(err, &validationErr) {
+					return admission.Errored(http.StatusBadRequest, validationErr)
+				}
+				var evaluationErr *cel.EvaluationError
+				if errors.As(err, &evaluationErr) {
+					return admission.Errored(http.StatusInternalServerError, evaluationErr)
+				}
+				return admission.Errored(http.StatusInternalServerError, err)
+			}
+		}
+		celPatches := metadataDiffPatches(plr, plrForCEL)
+		patches = append(patches, celPatches...)
+	}
+
+	return admission.Patched("kueue defaults applied", patches...)
+}
+
+// metadataDiffPatches computes JSON patches for label and annotation changes
+// between original and mutated PipelineRuns. Only metadata is compared —
+// spec fields are excluded to prevent zero-value leaks.
+func metadataDiffPatches(original, mutated *tekv1.PipelineRun) []jsonpatch.JsonPatchOperation {
+	var patches []jsonpatch.JsonPatchOperation
+
+	// Diff labels
+	if mutated.Labels != nil {
+		if original.Labels == nil {
+			patches = append(patches, jsonpatch.JsonPatchOperation{
+				Operation: "add",
+				Path:      "/metadata/labels",
+				Value:     mutated.Labels,
+			})
+		} else {
+			for k, v := range mutated.Labels {
+				if original.Labels[k] != v {
+					patches = append(patches, jsonpatch.JsonPatchOperation{
+						Operation: "add",
+						Path:      "/metadata/labels/" + escapeJSONPointer(k),
+						Value:     v,
+					})
+				}
 			}
 		}
 	}
-	return log
+
+	// Diff annotations
+	if mutated.Annotations != nil {
+		if original.Annotations == nil {
+			patches = append(patches, jsonpatch.JsonPatchOperation{
+				Operation: "add",
+				Path:      "/metadata/annotations",
+				Value:     mutated.Annotations,
+			})
+		} else {
+			for k, v := range mutated.Annotations {
+				if original.Annotations[k] != v {
+					patches = append(patches, jsonpatch.JsonPatchOperation{
+						Operation: "add",
+						Path:      "/metadata/annotations/" + escapeJSONPointer(k),
+						Value:     v,
+					})
+				}
+			}
+		}
+	}
+
+	return patches
 }
 
-// TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
+// escapeJSONPointer escapes special characters per RFC 6901.
+func escapeJSONPointer(s string) string {
+	s = strings.ReplaceAll(s, "~", "~0")
+	s = strings.ReplaceAll(s, "/", "~1")
+	return s
+}
 
-// +kubebuilder:webhook:path=/mutate-tekton-dev-v1-pipelinerun,mutating=true,failurePolicy=fail,sideEffects=None,groups=tekton.dev,resources=pipelineruns,verbs=create,versions=v1,name=pipelinerun-kueue-defaulter.tekton-kueue.io,admissionReviewVersions=v1
+// SetupPipelineRunWebhookWithManager registers the webhook handler directly
+// on the webhook server, bypassing controller-runtime's CustomDefaulter
+// struct round-trip pattern.
+func SetupPipelineRunWebhookWithManager(mgr ctrl.Manager, handler *PipelineRunWebhookHandler) error {
+	srv := mgr.GetWebhookServer()
+	srv.Register("/mutate-tekton-dev-v1-pipelinerun", &admission.Webhook{Handler: handler})
+	return nil
+}
 
-// PipelineRunCustomDefaulter struct is responsible for setting default values on the custom resource of the
-// Kind PipelineRun when those are created or updated.
-//
-// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
-// as it is used only for temporary operations and does not need to be deeply copied.
+// Legacy types kept for backward compatibility with the mutate CLI subcommand.
+// The CLI still uses CustomDefaulter because it doesn't go through the
+// admission webhook path and doesn't have the zero-value leak problem.
+
 type pipelineRunCustomDefaulter struct {
 	configStore *ConfigStore
 }
 
-func NewCustomDefaulter(configStore *ConfigStore) (webhook.CustomDefaulter, error) {
-	defaulter := &pipelineRunCustomDefaulter{
-		configStore: configStore,
-	}
-	return defaulter, nil
+func NewCustomDefaulter(configStore *ConfigStore) (*pipelineRunCustomDefaulter, error) {
+	return &pipelineRunCustomDefaulter{configStore: configStore}, nil
 }
 
-// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind PipelineRun.
-func (d *pipelineRunCustomDefaulter) Default(ctx context.Context, obj runtime.Object) error {
-	plr, ok := obj.(*tekv1.PipelineRun)
-
-	if !ok {
-		return k8serrors.NewBadRequest(fmt.Sprintf("expected a PipelineRun object but got %T", obj))
-	}
+func (d *pipelineRunCustomDefaulter) Default(ctx context.Context, plr *tekv1.PipelineRun) error {
 
 	plr.Spec.Status = tekv1.PipelineRunSpecStatusPending
 	if plr.Labels == nil {
@@ -108,21 +210,13 @@ func (d *pipelineRunCustomDefaulter) Default(ctx context.Context, obj runtime.Ob
 		plr.Labels[common.QueueLabel] = config.QueueName
 	}
 	if config.MultiKueueOverride {
-		plr.Spec.ManagedBy = ptr.To(common.ManagedByMultiKueueLabel)
+		managedBy := common.ManagedByMultiKueueLabel
+		plr.Spec.ManagedBy = &managedBy
 	}
 	for _, mutator := range mutators {
 		if err := mutator.Mutate(plr); err != nil {
-			var validationErr *cel.ValidationError
-			if errors.As(err, &validationErr) {
-				return k8serrors.NewBadRequest(validationErr.Error())
-			}
-			var evaluationErr *cel.EvaluationError
-			if errors.As(err, &evaluationErr) {
-				return k8serrors.NewInternalError(evaluationErr)
-			}
 			return err
 		}
 	}
-
 	return nil
 }

--- a/internal/webhook/v1/pipelinerun_webhook.go
+++ b/internal/webhook/v1/pipelinerun_webhook.go
@@ -24,10 +24,15 @@ import (
 	"strings"
 
 	"github.com/konflux-ci/tekton-kueue/internal/cel"
+	pkgconfig "github.com/konflux-ci/tekton-kueue/pkg/config"
 	"github.com/konflux-ci/tekton-kueue/pkg/common"
 	tekv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"gomodules.xyz/jsonpatch/v2"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -98,7 +103,6 @@ func (h *PipelineRunWebhookHandler) Handle(ctx context.Context, req admission.Re
 	//    resource annotations — all metadata, no spec fields. We apply them
 	//    to the decoded struct then diff only the metadata to build patches.
 	if len(mutators) > 0 {
-		// Deep copy so CEL mutations don't affect our original
 		plrForCEL := plr.DeepCopy()
 		for _, mutator := range mutators {
 			if err := mutator.Mutate(plrForCEL); err != nil {
@@ -126,7 +130,7 @@ func (h *PipelineRunWebhookHandler) Handle(ctx context.Context, req admission.Re
 func metadataDiffPatches(original, mutated *tekv1.PipelineRun) []jsonpatch.JsonPatchOperation {
 	var patches []jsonpatch.JsonPatchOperation
 
-	// Diff labels
+	// Diff labels: additions and modifications
 	if mutated.Labels != nil {
 		if original.Labels == nil {
 			patches = append(patches, jsonpatch.JsonPatchOperation{
@@ -144,10 +148,19 @@ func metadataDiffPatches(original, mutated *tekv1.PipelineRun) []jsonpatch.JsonP
 					})
 				}
 			}
+			// Detect deletions
+			for k := range original.Labels {
+				if _, exists := mutated.Labels[k]; !exists {
+					patches = append(patches, jsonpatch.JsonPatchOperation{
+						Operation: "remove",
+						Path:      "/metadata/labels/" + escapeJSONPointer(k),
+					})
+				}
+			}
 		}
 	}
 
-	// Diff annotations
+	// Diff annotations: additions and modifications
 	if mutated.Annotations != nil {
 		if original.Annotations == nil {
 			patches = append(patches, jsonpatch.JsonPatchOperation{
@@ -162,6 +175,15 @@ func metadataDiffPatches(original, mutated *tekv1.PipelineRun) []jsonpatch.JsonP
 						Operation: "add",
 						Path:      "/metadata/annotations/" + escapeJSONPointer(k),
 						Value:     v,
+					})
+				}
+			}
+			// Detect deletions
+			for k := range original.Annotations {
+				if _, exists := mutated.Annotations[k]; !exists {
+					patches = append(patches, jsonpatch.JsonPatchOperation{
+						Operation: "remove",
+						Path:      "/metadata/annotations/" + escapeJSONPointer(k),
 					})
 				}
 			}
@@ -187,36 +209,57 @@ func SetupPipelineRunWebhookWithManager(mgr ctrl.Manager, handler *PipelineRunWe
 	return nil
 }
 
-// Legacy types kept for backward compatibility with the mutate CLI subcommand.
-// The CLI still uses CustomDefaulter because it doesn't go through the
-// admission webhook path and doesn't have the zero-value leak problem.
-
-type pipelineRunCustomDefaulter struct {
-	configStore *ConfigStore
-}
-
-func NewCustomDefaulter(configStore *ConfigStore) (*pipelineRunCustomDefaulter, error) {
-	return &pipelineRunCustomDefaulter{configStore: configStore}, nil
-}
-
-func (d *pipelineRunCustomDefaulter) Default(ctx context.Context, plr *tekv1.PipelineRun) error {
-
+// ApplyMutations applies all kueue mutations to a PipelineRun in-place.
+// Used by both the legacy CustomDefaulter (for the mutate CLI) and can be
+// used for testing. This is the single source of truth for mutation logic.
+func ApplyMutations(plr *tekv1.PipelineRun, cfg *pkgconfig.Config, mutators []PipelineRunMutator) error {
 	plr.Spec.Status = tekv1.PipelineRunSpecStatusPending
 	if plr.Labels == nil {
 		plr.Labels = make(map[string]string)
 	}
-	config, mutators := d.configStore.GetConfigAndMutators()
 	if _, exists := plr.Labels[common.QueueLabel]; !exists {
-		plr.Labels[common.QueueLabel] = config.QueueName
+		plr.Labels[common.QueueLabel] = cfg.QueueName
 	}
-	if config.MultiKueueOverride {
-		managedBy := common.ManagedByMultiKueueLabel
-		plr.Spec.ManagedBy = &managedBy
+	if cfg.MultiKueueOverride {
+		plr.Spec.ManagedBy = ptr.To(common.ManagedByMultiKueueLabel)
 	}
 	for _, mutator := range mutators {
 		if err := mutator.Mutate(plr); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// pipelineRunCustomDefaulter implements webhook.CustomDefaulter for backward
+// compatibility with the mutate CLI subcommand. The CLI operates on local
+// files (no admission webhook path), so the zero-value leak doesn't apply.
+type pipelineRunCustomDefaulter struct {
+	configStore *ConfigStore
+}
+
+func NewCustomDefaulter(configStore *ConfigStore) (webhook.CustomDefaulter, error) {
+	return &pipelineRunCustomDefaulter{configStore: configStore}, nil
+}
+
+// Default implements webhook.CustomDefaulter.
+func (d *pipelineRunCustomDefaulter) Default(ctx context.Context, obj runtime.Object) error {
+	plr, ok := obj.(*tekv1.PipelineRun)
+	if !ok {
+		return k8serrors.NewBadRequest(fmt.Sprintf("expected a PipelineRun object but got %T", obj))
+	}
+
+	cfg, mutators := d.configStore.GetConfigAndMutators()
+	if err := ApplyMutations(plr, cfg, mutators); err != nil {
+		var validationErr *cel.ValidationError
+		if errors.As(err, &validationErr) {
+			return k8serrors.NewBadRequest(validationErr.Error())
+		}
+		var evaluationErr *cel.EvaluationError
+		if errors.As(err, &evaluationErr) {
+			return k8serrors.NewInternalError(evaluationErr)
+		}
+		return err
 	}
 	return nil
 }

--- a/internal/webhook/v1/pipelinerun_webhook_test.go
+++ b/internal/webhook/v1/pipelinerun_webhook_test.go
@@ -27,8 +27,12 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	tektondevv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"gomodules.xyz/jsonpatch/v2"
+	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 func TestV1Webhook(t *testing.T) {
@@ -338,6 +342,126 @@ var _ = Describe("PipelineRun Webhook", func() {
 				To(And(
 					Satisfy(errors.IsBadRequest),
 					MatchError(ContainSubstring("expected a PipelineRun object but got *v1.Pipeline"))))
+		})
+	})
+})
+
+var _ = Describe("PipelineRunWebhookHandler", func() {
+	var (
+		handler *PipelineRunWebhookHandler
+	)
+
+	makeRequest := func(plr *tektondevv1.PipelineRun) admission.Request {
+		raw, err := json.Marshal(plr)
+		Expect(err).NotTo(HaveOccurred())
+		return admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				Object: k8sruntime.RawExtension{Raw: raw},
+			},
+		}
+	}
+
+	findPatch := func(patches []jsonpatch.JsonPatchOperation, path string) *jsonpatch.JsonPatchOperation {
+		for _, p := range patches {
+			if p.Path == path {
+				return &p
+			}
+		}
+		return nil
+	}
+
+	Context("Handle", func() {
+		It("should set spec.status and queue label on a minimal PipelineRun", func(ctx context.Context) {
+			cfgStore := &ConfigStore{config: &config.Config{QueueName: "test-queue"}}
+			handler = NewWebhookHandler(cfgStore, admission.NewDecoder(k8sruntime.NewScheme()))
+
+			plr := &tektondevv1.PipelineRun{
+				Spec: tektondevv1.PipelineRunSpec{
+					PipelineRef: &tektondevv1.PipelineRef{Name: "test"},
+				},
+			}
+			resp := handler.Handle(ctx, makeRequest(plr))
+			Expect(resp.Allowed).To(BeTrue())
+			Expect(resp.Patches).NotTo(BeEmpty())
+
+			statusPatch := findPatch(resp.Patches, "/spec/status")
+			Expect(statusPatch).NotTo(BeNil())
+			Expect(statusPatch.Value).To(Equal("PipelineRunPending"))
+
+			labelPatch := findPatch(resp.Patches, "/metadata/labels")
+			Expect(labelPatch).NotTo(BeNil())
+		})
+
+		It("should not add queue label if already present", func(ctx context.Context) {
+			cfgStore := &ConfigStore{config: &config.Config{QueueName: "test-queue"}}
+			handler = NewWebhookHandler(cfgStore, admission.NewDecoder(k8sruntime.NewScheme()))
+
+			plr := &tektondevv1.PipelineRun{
+				Spec: tektondevv1.PipelineRunSpec{
+					PipelineRef: &tektondevv1.PipelineRef{Name: "test"},
+				},
+			}
+			plr.Labels = map[string]string{common.QueueLabel: "existing-queue"}
+			resp := handler.Handle(ctx, makeRequest(plr))
+			Expect(resp.Allowed).To(BeTrue())
+
+			// Should not have a label patch since queue label already exists
+			queuePatch := findPatch(resp.Patches, "/metadata/labels/"+escapeJSONPointer(common.QueueLabel))
+			Expect(queuePatch).To(BeNil())
+		})
+
+		It("should set managedBy when multiKueueOverride is true", func(ctx context.Context) {
+			cfgStore := &ConfigStore{config: &config.Config{QueueName: "test-queue", MultiKueueOverride: true}}
+			handler = NewWebhookHandler(cfgStore, admission.NewDecoder(k8sruntime.NewScheme()))
+
+			plr := &tektondevv1.PipelineRun{
+				Spec: tektondevv1.PipelineRunSpec{
+					PipelineRef: &tektondevv1.PipelineRef{Name: "test"},
+				},
+			}
+			resp := handler.Handle(ctx, makeRequest(plr))
+			Expect(resp.Allowed).To(BeTrue())
+
+			managedByPatch := findPatch(resp.Patches, "/spec/managedBy")
+			Expect(managedByPatch).NotTo(BeNil())
+			Expect(managedByPatch.Value).To(Equal(common.ManagedByMultiKueueLabel))
+		})
+
+		It("should NOT include serviceAccountName in patches", func(ctx context.Context) {
+			cfgStore := &ConfigStore{config: &config.Config{QueueName: "test-queue"}}
+			handler = NewWebhookHandler(cfgStore, admission.NewDecoder(k8sruntime.NewScheme()))
+
+			plr := &tektondevv1.PipelineRun{
+				Spec: tektondevv1.PipelineRunSpec{
+					PipelineRef: &tektondevv1.PipelineRef{Name: "test"},
+				},
+			}
+			resp := handler.Handle(ctx, makeRequest(plr))
+			Expect(resp.Allowed).To(BeTrue())
+
+			// This is the core assertion: no patch should touch serviceAccountName
+			for _, p := range resp.Patches {
+				Expect(p.Path).NotTo(ContainSubstring("serviceAccountName"),
+					"Patch should not contain serviceAccountName — this would prevent Tekton webhook from applying defaults")
+				Expect(p.Path).NotTo(ContainSubstring("taskRunTemplate"),
+					"Patch should not contain taskRunTemplate — this would leak zero-value fields")
+			}
+		})
+
+		It("should not set managedBy when multiKueueOverride is false", func(ctx context.Context) {
+			cfgStore := &ConfigStore{config: &config.Config{QueueName: "test-queue", MultiKueueOverride: false}}
+			handler = NewWebhookHandler(cfgStore, admission.NewDecoder(k8sruntime.NewScheme()))
+
+			plr := &tektondevv1.PipelineRun{
+				Spec: tektondevv1.PipelineRunSpec{
+					PipelineRef: &tektondevv1.PipelineRef{Name: "test"},
+				},
+			}
+			resp := handler.Handle(ctx, makeRequest(plr))
+			Expect(resp.Allowed).To(BeTrue())
+
+			managedByPatch := findPatch(resp.Patches, "/spec/managedBy")
+			Expect(managedByPatch).To(BeNil())
 		})
 	})
 })

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -694,6 +694,39 @@ var _ = Describe("Manager", Ordered, func() {
 			Expect(k8sClient.Create(ctx, plr)).Should(MatchError(kerrors.IsInvalid, "Invalid"))
 		})
 	})
+
+	Context("Webhook does not leak zero-value spec fields", Ordered, Label("smoke"), func() {
+		// Regression test for https://github.com/konflux-ci/tekton-kueue/issues/319
+		// The webhook must NOT include serviceAccountName or taskRunTemplate in
+		// its patches, so that downstream Tekton webhook can apply config-defaults.
+		It("should not set serviceAccountName on created PipelineRun", func(ctx context.Context) {
+			plr := plrTemplate.DeepCopy()
+			Eventually(
+				func() error {
+					return k8sClient.Create(ctx, plr)
+				},
+				90*time.Second,
+				3*time.Second,
+			).Should(Succeed())
+
+			// Re-fetch to get the object as stored by the API server
+			fetched := &tekv1.PipelineRun{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, client.ObjectKeyFromObject(plr), fetched)
+			}, 30*time.Second, time.Second).Should(Succeed())
+
+			// The webhook should have set status=Pending and queue label
+			Expect(fetched.Spec.Status).To(Equal(tekv1.PipelineRunSpecStatusPending))
+			Expect(fetched.Labels[common.QueueLabel]).NotTo(BeEmpty())
+
+			// The webhook must NOT have set serviceAccountName to "default".
+			// If empty, Tekton's webhook will apply the configured default (e.g., "pipeline").
+			// If "default", the zero-value leak bug is present.
+			sa := fetched.Spec.TaskRunTemplate.ServiceAccountName
+			Expect(sa).NotTo(Equal("default"),
+				"serviceAccountName should not be 'default' — this indicates the webhook is leaking zero-value fields")
+		})
+	})
 })
 
 func EnsureMatchingWorkloadExistWithStatusCondition(


### PR DESCRIPTION
# Changes

Replace the `CustomDefaulter` pattern (struct round-trip serialization) with a direct `admission.Handler` that returns explicit JSON patches.

## Problem

The `CustomDefaulter` pattern deserializes the admission request into a typed Go struct, applies mutations, then re-serializes the full struct to compute a diff. This leaks zero-value fields (like `serviceAccountName: ""`) into the patch, preventing the downstream Tekton webhook from applying `default-service-account: pipeline` from `config-defaults`.

Result: PipelineRuns get `serviceAccountName: "default"` instead of `"pipeline"` when the scheduler is enabled.

## Fix

The new `PipelineRunWebhookHandler` implements `admission.Handler` directly and builds JSON patches for only the fields we intend to modify:

- `/spec/status` -> PipelineRunPending
- `/metadata/labels/kueue.x-k8s.io~1queue-name` -> queue name
- `/spec/managedBy` -> multikueue label (if enabled)
- CEL mutations -> labels/annotations only (diffed via `metadataDiffPatches`)

No spec fields beyond `status` and `managedBy` are touched, so downstream webhooks see the object cleanly.

Shared `ApplyMutations()` function ensures the legacy `CustomDefaulter` (used by the mutate CLI) stays in sync with the webhook handler without code duplication.

# Submitter Checklist

- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Release notes block below has been updated with any user facing changes

# Tests

- 5 new unit tests for `PipelineRunWebhookHandler.Handle()`:
  - Sets spec.status and queue label correctly
  - Does not duplicate existing queue label
  - Sets managedBy only when multiKueueOverride is true
  - **Does NOT include serviceAccountName or taskRunTemplate in patches** (core bug fix assertion)
  - Does not set managedBy when multiKueueOverride is false
- 1 new e2e regression test: verifies serviceAccountName is not set to "default" on created PipelineRuns
- All 22 unit tests pass, integration test compiles

# Release Notes

```release-note
Fix webhook mutation leaking zero-value fields (e.g., serviceAccountName) that prevented downstream Tekton webhook from applying default-service-account configuration. The webhook now uses explicit JSON patches instead of struct round-trip serialization.
```

Fixes: https://github.com/konflux-ci/tekton-kueue/issues/319
Related: https://github.com/tektoncd/pipeline/issues/9647