### PR TITLE
fix: filter leaked zero-value fields from webhook admission patches

### DIFF
--- a/internal/webhook/v1/pipelinerun_webhook.go
+++ b/internal/webhook/v1/pipelinerun_webhook.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/konflux-ci/tekton-kueue/internal/cel"
@@ -36,11 +37,64 @@ import (
 )
 
 // SetupPipelineRunWebhookWithManager registers the webhook for PipelineRun in the manager.
+// It wraps the standard CustomDefaulter handler with a patch filter to prevent
+// controller-runtime's struct round-tripping from leaking zero-value fields
+// (e.g. taskRunTemplate: {}) into the admission response. Such leaks block
+// downstream webhooks (Tekton's) from applying their own defaults.
+// See https://github.com/konflux-ci/tekton-kueue/issues/319
 func SetupPipelineRunWebhookWithManager(mgr ctrl.Manager, defaulter admission.CustomDefaulter) error {
-	return ctrl.NewWebhookManagedBy(mgr).For(&tekv1.PipelineRun{}).
-		WithDefaulter(defaulter).
-		WithLogConstructor(logConstructor).
-		Complete()
+	inner := admission.WithCustomDefaulter(mgr.GetScheme(), &tekv1.PipelineRun{}, defaulter)
+	handler := &patchFilteringWebhook{inner: inner}
+	mgr.GetWebhookServer().Register(
+		"/mutate-tekton-dev-v1-pipelinerun",
+		&admission.Webhook{Handler: handler, LogConstructor: logConstructor},
+	)
+	return nil
+}
+
+// allowedPatchPrefixes lists the JSON Pointer prefixes for fields that the
+// webhook intentionally modifies. Any patch outside this allowlist is a
+// side-effect of Go struct round-tripping and gets dropped.
+var allowedPatchPrefixes = []string{
+	"/metadata/labels",
+	"/metadata/annotations",
+	"/spec/status",
+	"/spec/managedBy",
+}
+
+// patchFilteringWebhook wraps an admission.Handler and strips JSON patches
+// that target fields the webhook never intends to modify.
+type patchFilteringWebhook struct {
+	inner admission.Handler
+}
+
+func (w *patchFilteringWebhook) Handle(ctx context.Context, req admission.Request) admission.Response {
+	resp := w.inner.Handle(ctx, req)
+	if len(resp.Patches) == 0 {
+		return resp
+	}
+
+	n := 0
+	for _, p := range resp.Patches {
+		if isPatchAllowed(p.Path) {
+			resp.Patches[n] = p
+			n++
+		}
+	}
+	resp.Patches = resp.Patches[:n]
+	if n == 0 {
+		resp.PatchType = nil
+	}
+	return resp
+}
+
+func isPatchAllowed(path string) bool {
+	for _, prefix := range allowedPatchPrefixes {
+		if strings.HasPrefix(path, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func logConstructor(base logr.Logger, req *admission.Request) logr.Logger {
@@ -70,8 +124,6 @@ func logConstructor(base logr.Logger, req *admission.Request) logr.Logger {
 	}
 	return log
 }
-
-// TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
 // +kubebuilder:webhook:path=/mutate-tekton-dev-v1-pipelinerun,mutating=true,failurePolicy=fail,sideEffects=None,groups=tekton.dev,resources=pipelineruns,verbs=create,versions=v1,name=pipelinerun-kueue-defaulter.tekton-kueue.io,admissionReviewVersions=v1
 

--- a/internal/webhook/v1/pipelinerun_webhook_test.go
+++ b/internal/webhook/v1/pipelinerun_webhook_test.go
@@ -19,6 +19,8 @@ package v1
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/konflux-ci/tekton-kueue/internal/cel"
@@ -27,8 +29,11 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	tektondevv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 func TestV1Webhook(t *testing.T) {
@@ -339,5 +344,100 @@ var _ = Describe("PipelineRun Webhook", func() {
 					Satisfy(errors.IsBadRequest),
 					MatchError(ContainSubstring("expected a PipelineRun object but got *v1.Pipeline"))))
 		})
+	})
+})
+
+// minimalPipelineRunJSON is a raw admission request as it would arrive from
+// kubectl — no taskRunTemplate, no serviceAccountName, no status sub-resource.
+var minimalPipelineRunJSON = []byte(`{
+	"apiVersion": "tekton.dev/v1",
+	"kind": "PipelineRun",
+	"metadata": {
+		"name": "test-plr",
+		"namespace": "default"
+	},
+	"spec": {
+		"pipelineRef": {"name": "test-pipeline"}
+	}
+}`)
+
+// fieldsWeNeverTouch lists spec/status fields the webhook should never patch.
+var fieldsWeNeverTouch = []string{
+	"taskRunTemplate",
+	"serviceAccountName",
+	"taskRunSpecs",
+	"workspaces",
+	"timeouts",
+}
+
+func makeAdmissionRequest(raw []byte) admission.Request {
+	return admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Object:    k8sruntime.RawExtension{Raw: raw},
+			Operation: admissionv1.Create,
+		},
+	}
+}
+
+var _ = Describe("Zero-value field leak (issue #319)", func() {
+	var (
+		cfgStore *ConfigStore
+		scheme   *k8sruntime.Scheme
+	)
+
+	BeforeEach(func() {
+		cfgStore = &ConfigStore{config: &config.Config{QueueName: "test-queue"}}
+		scheme = k8sruntime.NewScheme()
+		Expect(tektondevv1.AddToScheme(scheme)).To(Succeed())
+	})
+
+	It("raw CustomDefaulter leaks zero-value struct fields into patches", func(ctx context.Context) {
+		defaulter, err := NewCustomDefaulter(cfgStore)
+		Expect(err).NotTo(HaveOccurred())
+
+		unfiltered := admission.WithCustomDefaulter(scheme, &tektondevv1.PipelineRun{}, defaulter)
+		resp := unfiltered.Handle(ctx, makeAdmissionRequest(minimalPipelineRunJSON))
+		Expect(resp.Allowed).To(BeTrue())
+
+		_, _ = fmt.Fprintf(GinkgoWriter, "\n=== Unfiltered patches (%d) ===\n", len(resp.Patches))
+		for i, p := range resp.Patches {
+			_, _ = fmt.Fprintf(GinkgoWriter, "  [%d] op=%-7s path=%s\n", i, p.Operation, p.Path)
+		}
+
+		leaked := false
+		for _, p := range resp.Patches {
+			for _, field := range fieldsWeNeverTouch {
+				if strings.Contains(p.Path, field) {
+					leaked = true
+				}
+			}
+		}
+		Expect(leaked).To(BeTrue(),
+			"expected the raw CustomDefaulter to leak zero-value fields — "+
+				"if this passes, Go's json.Marshal omitempty behavior may have changed")
+	})
+
+	It("patchFilteringWebhook strips the leaked fields", func(ctx context.Context) {
+		defaulter, err := NewCustomDefaulter(cfgStore)
+		Expect(err).NotTo(HaveOccurred())
+
+		inner := admission.WithCustomDefaulter(scheme, &tektondevv1.PipelineRun{}, defaulter)
+		filtered := &patchFilteringWebhook{inner: inner}
+
+		resp := filtered.Handle(ctx, makeAdmissionRequest(minimalPipelineRunJSON))
+		Expect(resp.Allowed).To(BeTrue())
+		Expect(resp.Patches).NotTo(BeEmpty())
+
+		_, _ = fmt.Fprintf(GinkgoWriter, "\n=== Filtered patches (%d) ===\n", len(resp.Patches))
+		for i, p := range resp.Patches {
+			_, _ = fmt.Fprintf(GinkgoWriter, "  [%d] op=%-7s path=%s\n", i, p.Operation, p.Path)
+		}
+
+		for _, p := range resp.Patches {
+			for _, field := range fieldsWeNeverTouch {
+				Expect(p.Path).NotTo(ContainSubstring(field),
+					fmt.Sprintf("patch at %s still contains '%s' after filtering", p.Path, field))
+			}
+		}
 	})
 })


### PR DESCRIPTION
controller-runtime's CustomDefaulter re-marshals the full Go struct after Default() and diffs it against the original raw JSON. Because Go's encoding/json omitempty does not omit zero-value structs, fields like taskRunTemplate:{} and status:{} leak into the admission patch even though the webhook never modifies them. This prevents the downstream Tekton webhook from applying its own defaults (e.g. default-service-account from config-defaults).

Wrap the built-in CustomDefaulter handler with a patchFilteringWebhook that strips patches outside an explicit allowlist of fields the webhook intends to modify (/metadata/labels, /metadata/annotations, /spec/status, /spec/managedBy). The Default() function and all existing mutation logic remain unchanged.

Note: this workaround will become unnecessary if either:
- Tekton Pipeline types adopt Go 1.24's omitzero struct tag on value-type fields like TaskRunTemplate, or
- controller-runtime switches to encoding/json/v2, where omitempty correctly omits empty JSON objects ({}).

Fixes: https://github.com/konflux-ci/tekton-kueue/issues/319
Related: https://github.com/tektoncd/pipeline/issues/9647

Assisted-By: Cursor