### PR TITLE
Block incompatible dependency upgrades in Renovate/MintMaker

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -101,6 +101,30 @@
       "matchManagers": ["rpm-lockfile"],
       "automerge": true,
       "addLabels": ["approved", "lgtm", "auto-merged"]
+    },
+    {
+      "description": "Block kueue upgrades beyond 0.14.x — infra-deployments kueue only serves v1beta1 with no conversion webhook, and kueue >=0.15 requires v1beta2",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["sigs.k8s.io/kueue"],
+      "allowedVersions": "<0.15.0"
+    },
+    {
+      "description": "Block k8s library upgrades beyond 0.34.x — kueue v0.14.x is incompatible with k8s >=0.35 due to breaking API changes (e.g. FindMatchingUntoleratedTaint signature)",
+      "matchManagers": ["gomod"],
+      "matchPackagePatterns": ["^k8s\\.io/"],
+      "allowedVersions": "<0.35.0"
+    },
+    {
+      "description": "Block controller-runtime upgrades beyond 0.22.x — kueue v0.14.x is incompatible with controller-runtime >=0.23 due to breaking changes in webhook and defaulter interfaces",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["sigs.k8s.io/controller-runtime"],
+      "allowedVersions": "<0.23.0"
+    },
+    {
+      "description": "Block tektoncd/pipeline upgrades beyond 1.10.x — v1.11+ pulls k8s >=0.35 which is incompatible with kueue v0.14.x",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["github.com/tektoncd/pipeline"],
+      "allowedVersions": "<1.11.0"
     }
   ]
 }


### PR DESCRIPTION
Add allowedVersions constraints to prevent Renovate from proposing upgrades that are incompatible with the kueue v1beta1 API currently deployed in infra-deployments:

- kueue <0.15.0: v0.15+ requires v1beta2
- k8s.io/* <0.35.0: kueue v0.14.x breaks with k8s 0.35+ API changes
- controller-runtime <0.23.0: kueue v0.14.x breaks with CR 0.23+
- tektoncd/pipeline <1.11.0: v1.11+ pulls k8s 0.35+ transitively

These constraints can be lifted once infra-deployments upgrades kueue to a version that serves v1beta2.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

Contributes to: KFLUXINFRA-3008