### PR TITLE
[cherry-pick: release-v0.3.x] fix: filter leaked zero-value fields from webhook admission patches

### DIFF
--- a/internal/cel/mutator.go
+++ b/internal/cel/mutator.go
@@ -83,7 +83,7 @@ func (m *CELMutator) Mutate(pipelineRun *tekv1.PipelineRun) error {
 		pipelineRun, err = mutate(pipelineRun, mutation)
 		if err != nil {
 			RecordMutationFailure()
-			return fmt.Errorf("failed to apply mutation (type: %s, key: %s): %w", mutation.Type, mutation.Key, err)
+			return &EvaluationError{Err: fmt.Errorf("failed to apply mutation (type: %s, key: %s): %w", mutation.Type, mutation.Key, err)}
 		}
 	}
 

--- a/internal/cel/mutator.go
+++ b/internal/cel/mutator.go
@@ -1,6 +1,7 @@
 package cel
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
@@ -37,6 +38,11 @@ func NewCELMutator(programs []*CompiledProgram) *CELMutator {
 // It evaluates each compiled program and applies the resulting mutations
 // to the PipelineRun's labels and annotations.
 //
+// A deep copy of the PipelineRun with defaults applied is used for CEL
+// evaluation (required for JSON marshaling in structToCELMap), but all
+// mutations are applied to the original PipelineRun to avoid permanently
+// overriding cluster-level defaults (e.g., TektonConfig timeouts).
+//
 // The PipelineRun is modified in-place. If any evaluation fails, the method
 // returns an error and the PipelineRun may be partially modified.
 //
@@ -46,7 +52,29 @@ func NewCELMutator(programs []*CompiledProgram) *CELMutator {
 // Returns:
 //   - error: Any error that occurred during evaluation or mutation
 func (m *CELMutator) Mutate(pipelineRun *tekv1.PipelineRun) error {
-	mutations, err := m.evaluate(pipelineRun)
+	if pipelineRun == nil {
+		return fmt.Errorf("pipelineRun cannot be nil")
+	}
+
+	// Nothing to evaluate — skip deep copy, defaults, and validation.
+	if len(m.programs) == 0 {
+		RecordMutationSuccess()
+		return nil
+	}
+
+	// Deep copy, set defaults, and validate for CEL evaluation. The copy is
+	// needed because structToCELMap (json.Marshal) can fail on PipelineRuns
+	// without defaults (e.g., missing ParamSpec.Type). We must not set defaults
+	// on the original to avoid overriding cluster-level TektonConfig defaults
+	// like timeouts.
+	plrCopy := pipelineRun.DeepCopy()
+	plrCopy.Spec.SetDefaults(context.TODO())
+
+	if errs := plrCopy.Spec.Validate(context.TODO()); errs != nil {
+		return &ValidationError{Err: fmt.Errorf("invalid pipelinerun: %v", errs)}
+	}
+
+	mutations, err := m.evaluate(plrCopy)
 	if err != nil {
 		return err
 	}

--- a/internal/cel/mutator_test.go
+++ b/internal/cel/mutator_test.go
@@ -36,11 +36,11 @@ const (
 	buildPlatformsExpression = `has(pipelineRun.spec.params) &&
 		pipelineRun.spec.params.exists(p, p.name == 'build-platforms') ?
 		pipelineRun.spec.params.filter(
-		  p, 
+		  p,
 		  p.name == 'build-platforms')[0]
 		.value.map(
 		  p,
-		  annotation("kueue.konflux-ci.dev/requests-" + replace(p, "/", "-"), "1") 
+		  annotation("kueue.konflux-ci.dev/requests-" + replace(p, "/", "-"), "1")
 		) : []`
 
 	oldStylePlatformsExpression = `has(pipelineRun.spec.pipelineSpec) &&
@@ -94,7 +94,8 @@ func getBuildPlatformsParamsSmall() []tekv1.Param {
 func getPipelineTasksWithPlatforms() []tekv1.PipelineTask {
 	return []tekv1.PipelineTask{
 		{
-			Name: "build-arm64",
+			Name:    "build-arm64",
+			TaskRef: &tekv1.TaskRef{Name: "build-task"},
 			Params: []tekv1.Param{
 				{
 					Name:  "PLATFORM",
@@ -103,7 +104,8 @@ func getPipelineTasksWithPlatforms() []tekv1.PipelineTask {
 			},
 		},
 		{
-			Name: "build-amd64",
+			Name:    "build-amd64",
+			TaskRef: &tekv1.TaskRef{Name: "build-task"},
 			Params: []tekv1.Param{
 				{
 					Name:  "PLATFORM",
@@ -112,7 +114,8 @@ func getPipelineTasksWithPlatforms() []tekv1.PipelineTask {
 			},
 		},
 		{
-			Name: "build-s390x",
+			Name:    "build-s390x",
+			TaskRef: &tekv1.TaskRef{Name: "build-task"},
 			Params: []tekv1.Param{
 				{
 					Name:  "PLATFORM",
@@ -121,7 +124,8 @@ func getPipelineTasksWithPlatforms() []tekv1.PipelineTask {
 			},
 		},
 		{
-			Name: "no-platform-task",
+			Name:    "no-platform-task",
+			TaskRef: &tekv1.TaskRef{Name: "other-task"},
 			// No PLATFORM parameter
 		},
 	}
@@ -131,7 +135,8 @@ func getPipelineTasksWithPlatforms() []tekv1.PipelineTask {
 func getPipelineTasksWithoutPlatforms() []tekv1.PipelineTask {
 	return []tekv1.PipelineTask{
 		{
-			Name: "setup",
+			Name:    "setup",
+			TaskRef: &tekv1.TaskRef{Name: "setup-task"},
 			Params: []tekv1.Param{
 				{
 					Name:  "VERSION",
@@ -140,7 +145,8 @@ func getPipelineTasksWithoutPlatforms() []tekv1.PipelineTask {
 			},
 		},
 		{
-			Name: "cleanup",
+			Name:    "cleanup",
+			TaskRef: &tekv1.TaskRef{Name: "cleanup-task"},
 			// No parameters
 		},
 	}
@@ -489,7 +495,7 @@ func TestCELMutator_Mutate(t *testing.T) {
 			initialLabels:       nil,
 			initialAnnotations:  nil,
 			initialParams:       nil,
-			pipelineSpec:        &tekv1.PipelineSpec{},
+			pipelineSpec:        &tekv1.PipelineSpec{Description: "test pipeline"},
 			expectedLabels:      nil,
 			expectedAnnotations: nil,
 			expectErr:           false,

--- a/internal/webhook/v1/pipelinerun_webhook.go
+++ b/internal/webhook/v1/pipelinerun_webhook.go
@@ -18,10 +18,11 @@ package v1
 
 import (
 	"context"
-	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/go-logr/logr"
+	"github.com/konflux-ci/tekton-kueue/internal/cel"
 	"github.com/konflux-ci/tekton-kueue/pkg/common"
 	tekv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -98,28 +99,6 @@ func (d *pipelineRunCustomDefaulter) Default(ctx context.Context, obj runtime.Ob
 		return k8serrors.NewBadRequest(fmt.Sprintf("expected a PipelineRun object but got %T", obj))
 	}
 
-	// Set default values and attempt to catch bad pipelineruns prior to processing so we can catch
-	// errors ourselves and handle them appropriately.  Only validate the spec
-	// field, since we might be getting a pipelinerun with a generated name, which
-	// the top-level Validate() method will reject
-	plr.Spec.SetDefaults(ctx)
-	if err := plr.Spec.Validate(ctx); err != nil {
-		return k8serrors.NewBadRequest(fmt.Sprintf("invalid pipelinerun: %v", err))
-	}
-
-	// Attempt to serialize the pipelinerun, and return 400 Bad Request if it fails.  We only want
-	// to process valid resources, but since this is a mutation webhook, validation webhooks
-	// haven't processed this resource yet.  This may cause problems in the future if we have other
-	// mutation webhooks on pipelineruns, since kubernetes does not guarantee an order in
-	// processing mutation webhooks.
-	//
-	// TODO(@sadlerap): only do this marshalling once, we do a bunch of marshalling inside the
-	// mutators as well so this is duplicate work
-	if _, err := json.Marshal(plr); err != nil {
-		// bad request
-		return k8serrors.NewBadRequest(fmt.Sprintf("failed to serialize pipelinerun: %v", err))
-	}
-
 	plr.Spec.Status = tekv1.PipelineRunSpecStatusPending
 	if plr.Labels == nil {
 		plr.Labels = make(map[string]string)
@@ -133,6 +112,10 @@ func (d *pipelineRunCustomDefaulter) Default(ctx context.Context, obj runtime.Ob
 	}
 	for _, mutator := range mutators {
 		if err := mutator.Mutate(plr); err != nil {
+			var validationErr *cel.ValidationError
+			if errors.As(err, &validationErr) {
+				return k8serrors.NewBadRequest(validationErr.Error())
+			}
 			return err
 		}
 	}

--- a/internal/webhook/v1/pipelinerun_webhook.go
+++ b/internal/webhook/v1/pipelinerun_webhook.go
@@ -95,7 +95,7 @@ func (d *pipelineRunCustomDefaulter) Default(ctx context.Context, obj runtime.Ob
 	plr, ok := obj.(*tekv1.PipelineRun)
 
 	if !ok {
-		return k8serrors.NewBadRequest(fmt.Sprintf("expected an PipelineRun object but got %T", obj))
+		return k8serrors.NewBadRequest(fmt.Sprintf("expected a PipelineRun object but got %T", obj))
 	}
 
 	// Set default values and attempt to catch bad pipelineruns prior to processing so we can catch
@@ -103,9 +103,8 @@ func (d *pipelineRunCustomDefaulter) Default(ctx context.Context, obj runtime.Ob
 	// field, since we might be getting a pipelinerun with a generated name, which
 	// the top-level Validate() method will reject
 	plr.Spec.SetDefaults(ctx)
-	err := plr.Spec.Validate(ctx)
-	if err != nil {
-		return k8serrors.NewBadRequest(err.Error())
+	if err := plr.Spec.Validate(ctx); err != nil {
+		return k8serrors.NewBadRequest(fmt.Sprintf("invalid pipelinerun: %v", err))
 	}
 
 	// Attempt to serialize the pipelinerun, and return 400 Bad Request if it fails.  We only want

--- a/internal/webhook/v1/pipelinerun_webhook.go
+++ b/internal/webhook/v1/pipelinerun_webhook.go
@@ -116,6 +116,10 @@ func (d *pipelineRunCustomDefaulter) Default(ctx context.Context, obj runtime.Ob
 			if errors.As(err, &validationErr) {
 				return k8serrors.NewBadRequest(validationErr.Error())
 			}
+			var evaluationErr *cel.EvaluationError
+			if errors.As(err, &evaluationErr) {
+				return k8serrors.NewInternalError(evaluationErr)
+			}
 			return err
 		}
 	}

--- a/internal/webhook/v1/pipelinerun_webhook.go
+++ b/internal/webhook/v1/pipelinerun_webhook.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/konflux-ci/tekton-kueue/internal/cel"
@@ -36,11 +37,64 @@ import (
 )
 
 // SetupPipelineRunWebhookWithManager registers the webhook for PipelineRun in the manager.
+// It wraps the standard CustomDefaulter handler with a patch filter to prevent
+// controller-runtime's struct round-tripping from leaking zero-value fields
+// (e.g. taskRunTemplate: {}) into the admission response. Such leaks block
+// downstream webhooks (Tekton's) from applying their own defaults.
+// See https://github.com/konflux-ci/tekton-kueue/issues/319
 func SetupPipelineRunWebhookWithManager(mgr ctrl.Manager, defaulter admission.CustomDefaulter) error {
-	return ctrl.NewWebhookManagedBy(mgr).For(&tekv1.PipelineRun{}).
-		WithDefaulter(defaulter).
-		WithLogConstructor(logConstructor).
-		Complete()
+	inner := admission.WithCustomDefaulter(mgr.GetScheme(), &tekv1.PipelineRun{}, defaulter)
+	handler := &patchFilteringWebhook{inner: inner}
+	mgr.GetWebhookServer().Register(
+		"/mutate-tekton-dev-v1-pipelinerun",
+		&admission.Webhook{Handler: handler, LogConstructor: logConstructor},
+	)
+	return nil
+}
+
+// allowedPatchPrefixes lists the JSON Pointer prefixes for fields that the
+// webhook intentionally modifies. Any patch outside this allowlist is a
+// side-effect of Go struct round-tripping and gets dropped.
+var allowedPatchPrefixes = []string{
+	"/metadata/labels",
+	"/metadata/annotations",
+	"/spec/status",
+	"/spec/managedBy",
+}
+
+// patchFilteringWebhook wraps an admission.Handler and strips JSON patches
+// that target fields the webhook never intends to modify.
+type patchFilteringWebhook struct {
+	inner admission.Handler
+}
+
+func (w *patchFilteringWebhook) Handle(ctx context.Context, req admission.Request) admission.Response {
+	resp := w.inner.Handle(ctx, req)
+	if len(resp.Patches) == 0 {
+		return resp
+	}
+
+	n := 0
+	for _, p := range resp.Patches {
+		if isPatchAllowed(p.Path) {
+			resp.Patches[n] = p
+			n++
+		}
+	}
+	resp.Patches = resp.Patches[:n]
+	if n == 0 {
+		resp.PatchType = nil
+	}
+	return resp
+}
+
+func isPatchAllowed(path string) bool {
+	for _, prefix := range allowedPatchPrefixes {
+		if strings.HasPrefix(path, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func logConstructor(base logr.Logger, req *admission.Request) logr.Logger {
@@ -70,8 +124,6 @@ func logConstructor(base logr.Logger, req *admission.Request) logr.Logger {
 	}
 	return log
 }
-
-// TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
 // +kubebuilder:webhook:path=/mutate-tekton-dev-v1-pipelinerun,mutating=true,failurePolicy=fail,sideEffects=None,groups=tekton.dev,resources=pipelineruns,verbs=create,versions=v1,name=pipelinerun-kueue-defaulter.tekton-kueue.io,admissionReviewVersions=v1
 

--- a/internal/webhook/v1/pipelinerun_webhook_test.go
+++ b/internal/webhook/v1/pipelinerun_webhook_test.go
@@ -19,6 +19,8 @@ package v1
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/konflux-ci/tekton-kueue/internal/cel"
@@ -27,8 +29,11 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	tektondevv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 func TestV1Webhook(t *testing.T) {
@@ -339,5 +344,100 @@ var _ = Describe("PipelineRun Webhook", func() {
 					Satisfy(errors.IsBadRequest),
 					MatchError(ContainSubstring("expected a PipelineRun object but got *v1.Pipeline"))))
 		})
+	})
+})
+
+// minimalPipelineRunJSON is a raw admission request as it would arrive from
+// kubectl — no taskRunTemplate, no serviceAccountName, no status sub-resource.
+var minimalPipelineRunJSON = []byte(`{
+	"apiVersion": "tekton.dev/v1",
+	"kind": "PipelineRun",
+	"metadata": {
+		"name": "test-plr",
+		"namespace": "default"
+	},
+	"spec": {
+		"pipelineRef": {"name": "test-pipeline"}
+	}
+}`)
+
+// fieldsWeNeverTouch lists spec/status fields the webhook should never patch.
+var fieldsWeNeverTouch = []string{
+	"taskRunTemplate",
+	"serviceAccountName",
+	"taskRunSpecs",
+	"workspaces",
+	"timeouts",
+}
+
+func makeAdmissionRequest(raw []byte) admission.Request {
+	return admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Object:    k8sruntime.RawExtension{Raw: raw},
+			Operation: admissionv1.Create,
+		},
+	}
+}
+
+var _ = Describe("Zero-value field leak (issue #319)", func() {
+	var (
+		cfgStore *ConfigStore
+		scheme   *k8sruntime.Scheme
+	)
+
+	BeforeEach(func() {
+		cfgStore = &ConfigStore{config: &config.Config{QueueName: "test-queue"}}
+		scheme = k8sruntime.NewScheme()
+		Expect(tektondevv1.AddToScheme(scheme)).To(Succeed())
+	})
+
+	It("raw CustomDefaulter leaks zero-value struct fields into patches", func(ctx context.Context) {
+		defaulter, err := NewCustomDefaulter(cfgStore)
+		Expect(err).NotTo(HaveOccurred())
+
+		unfiltered := admission.WithCustomDefaulter(scheme, &tektondevv1.PipelineRun{}, defaulter)
+		resp := unfiltered.Handle(ctx, makeAdmissionRequest(minimalPipelineRunJSON))
+		Expect(resp.Allowed).To(BeTrue())
+
+		_, _ = fmt.Fprintf(GinkgoWriter, "\n=== Unfiltered patches (%d) ===\n", len(resp.Patches))
+		for i, p := range resp.Patches {
+			_, _ = fmt.Fprintf(GinkgoWriter, "  [%d] op=%-7s path=%s\n", i, p.Operation, p.Path)
+		}
+
+		leaked := false
+		for _, p := range resp.Patches {
+			for _, field := range fieldsWeNeverTouch {
+				if strings.Contains(p.Path, field) {
+					leaked = true
+				}
+			}
+		}
+		Expect(leaked).To(BeTrue(),
+			"expected the raw CustomDefaulter to leak zero-value fields — "+
+				"if this passes, Go's json.Marshal omitempty behavior may have changed")
+	})
+
+	It("patchFilteringWebhook strips the leaked fields", func(ctx context.Context) {
+		defaulter, err := NewCustomDefaulter(cfgStore)
+		Expect(err).NotTo(HaveOccurred())
+
+		inner := admission.WithCustomDefaulter(scheme, &tektondevv1.PipelineRun{}, defaulter)
+		filtered := &patchFilteringWebhook{inner: inner}
+
+		resp := filtered.Handle(ctx, makeAdmissionRequest(minimalPipelineRunJSON))
+		Expect(resp.Allowed).To(BeTrue())
+		Expect(resp.Patches).NotTo(BeEmpty())
+
+		_, _ = fmt.Fprintf(GinkgoWriter, "\n=== Filtered patches (%d) ===\n", len(resp.Patches))
+		for i, p := range resp.Patches {
+			_, _ = fmt.Fprintf(GinkgoWriter, "  [%d] op=%-7s path=%s\n", i, p.Operation, p.Path)
+		}
+
+		for _, p := range resp.Patches {
+			for _, field := range fieldsWeNeverTouch {
+				Expect(p.Path).NotTo(ContainSubstring(field),
+					fmt.Sprintf("patch at %s still contains '%s' after filtering", p.Path, field))
+			}
+		}
 	})
 })

--- a/pkg/mutate/mutate_test.go
+++ b/pkg/mutate/mutate_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	tekv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/yaml"
 )
 
@@ -77,6 +78,43 @@ spec:
 			Expect(pipelineRun.Spec.Status).To(Equal(tekv1.PipelineRunSpecStatus(tekv1.PipelineRunSpecStatusPending)))
 		})
 
+		It("should mutate a PipelineRun with a CEL expression", func() {
+			// Write config file with CEL expressions
+			configPath := filepath.Join(tmpDir, "config.yaml")
+			configContent := `
+queueName: "test-queue"
+cel:
+  expressions:
+    - 'label("env", "production")'
+    - 'annotation("team", "platform")'
+`
+			Expect(os.WriteFile(configPath, []byte(configContent), 0644)).To(Succeed())
+
+			// Write PipelineRun file
+			plrContent := `apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: test-pipelinerun
+spec:
+  pipelineRef:
+    name: my-pipeline
+`
+			plrPath := filepath.Join(tmpDir, "pipelinerun.yaml")
+			Expect(os.WriteFile(plrPath, []byte(plrContent), 0644)).To(Succeed())
+
+			// Call MutatePipelineRun
+			mutatedData, err := MutatePipelineRun(plrPath, tmpDir)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Parse and validate
+			var pipelineRun tekv1.PipelineRun
+			Expect(yaml.Unmarshal(mutatedData, &pipelineRun)).To(Succeed())
+			Expect(pipelineRun.Labels[common.QueueLabel]).To(Equal("test-queue"))
+			Expect(pipelineRun.Labels["env"]).To(Equal("production"))
+			Expect(pipelineRun.Annotations["team"]).To(Equal("platform"))
+			Expect(pipelineRun.Spec.Status).To(Equal(tekv1.PipelineRunSpecStatus(tekv1.PipelineRunSpecStatusPending)))
+		})
+
 		It("should mutate a PipelineRun with pipelineSpec", func() {
 			// Write config file
 			configPath := filepath.Join(tmpDir, "config.yaml")
@@ -114,9 +152,16 @@ spec:
 
 	Context("with invalid PipelineRun", func() {
 		It("should reject a PipelineRun with neither pipelineRef nor pipelineSpec", func() {
-			// Write config file
+			// Write config file with a CEL expression so the CEL mutator is created
+			// and Validate() runs on the PipelineRun copy.
 			configPath := filepath.Join(tmpDir, "config.yaml")
-			Expect(os.WriteFile(configPath, []byte(`queueName: "test-queue"`), 0644)).To(Succeed())
+			configContent := `
+queueName: "test-queue"
+cel:
+  expressions:
+    - 'label("env", "test")'
+`
+			Expect(os.WriteFile(configPath, []byte(configContent), 0644)).To(Succeed())
 
 			// Write invalid PipelineRun file
 			plrContent := `apiVersion: tekton.dev/v1
@@ -128,9 +173,11 @@ spec: {}
 			plrPath := filepath.Join(tmpDir, "pipelinerun.yaml")
 			Expect(os.WriteFile(plrPath, []byte(plrContent), 0644)).To(Succeed())
 
-			// Call MutatePipelineRun - should fail
+			// Call MutatePipelineRun - should fail with a BadRequest error
 			_, err := MutatePipelineRun(plrPath, tmpDir)
 			Expect(err).To(HaveOccurred())
+			Expect(k8serrors.IsBadRequest(err)).To(BeTrue(), "expected BadRequest error, got: %v", err)
+			Expect(err.Error()).To(ContainSubstring("expected exactly one, got neither: pipelineRef, pipelineSpec"))
 		})
 	})
 


### PR DESCRIPTION
# Changes

Cherry-pick of #329 from main to `release-v0.3.x`.

Fixes the webhook mutating admission controller leaking zero-value fields (like empty `serviceAccountName`) into PipelineRun specs, which prevents Tekton's webhook from applying defaults like `default-service-account: pipeline`.

## Conflict Resolution

Import conflict in `pipelinerun_webhook_test.go` resolved — added new imports (`encoding/json`, `fmt`, `strings`, `admissionv1`, `k8sruntime`) needed by the cherry-picked test code.

/kind bug