### PR TITLE
fix: approve Renovate PRs only after CI passes, ungroup patch bumps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,6 @@
     "github>konflux-ci/mintmaker//config/renovate/renovate.json"
   ],
   "schedule": ["before 7am on Monday"],
-  "minimumReleaseAge": "3 days",
   "enabledManagers": [
     "tekton",
     "dockerfile",
@@ -24,12 +23,14 @@
   },
   "packageRules": [
     {
-      "description": "Group and auto-merge go module patch bumps together",
-      "groupName": "go-modules patch",
+      "description": "Individual PRs for go module patch bumps (auto-approved after CI passes)",
       "matchManagers": ["gomod"],
-      "matchUpdateTypes": ["patch", "digest"],
-      "automerge": true,
-      "addLabels": ["approved", "lgtm", "auto-merged"]
+      "matchUpdateTypes": ["patch"]
+    },
+    {
+      "description": "Individual PRs for go module digest bumps (pseudo-versions have no semver guarantees, treated as minor)",
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["digest"]
     },
     {
       "description": "Individual PRs for go module minor bumps",
@@ -51,7 +52,19 @@
     },
     {
       "description": "Label patch version bumps",
-      "matchUpdateTypes": ["patch", "digest"],
+      "matchUpdateTypes": ["patch"],
+      "addLabels": ["semver/patch"]
+    },
+    {
+      "description": "Label gomod digest bumps as minor — pseudo-versions lack semver guarantees and need impact analysis",
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["digest"],
+      "addLabels": ["semver/minor"]
+    },
+    {
+      "description": "Label non-gomod digest bumps as patch",
+      "excludeManagers": ["gomod"],
+      "matchUpdateTypes": ["digest"],
       "addLabels": ["semver/patch"]
     },
     {
@@ -79,16 +92,12 @@
     {
       "description": "Prioritize Konflux tekton task reference updates",
       "matchManagers": ["tekton"],
-      "prPriority": 10,
-      "automerge": true,
-      "addLabels": ["approved", "lgtm", "auto-merged"]
+      "prPriority": 10
     },
     {
-      "description": "Auto-merge dockerfile updates (except Go toolchain)",
+      "description": "Dockerfile updates (except Go toolchain, auto-approved after CI passes)",
       "matchManagers": ["dockerfile"],
-      "excludePackagePatterns": ["go-toolset"],
-      "automerge": true,
-      "addLabels": ["approved", "lgtm", "auto-merged"]
+      "excludePackagePatterns": ["go-toolset"]
     },
     {
       "description": "Go toolchain updates require manual review",
@@ -97,10 +106,8 @@
       "automerge": false
     },
     {
-      "description": "Auto-merge rpm-lockfile updates",
-      "matchManagers": ["rpm-lockfile"],
-      "automerge": true,
-      "addLabels": ["approved", "lgtm", "auto-merged"]
+      "description": "RPM lockfile updates (auto-approved after CI passes)",
+      "matchManagers": ["rpm-lockfile"]
     },
     {
       "description": "Block kueue upgrades beyond 0.14.x — infra-deployments kueue only serves v1beta1 with no conversion webhook, and kueue >=0.15 requires v1beta2",

--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -1,0 +1,147 @@
+name: Auto-approve low-risk dependency PRs
+
+# Runs after CI completes on a PR. If the PR is a low-risk Renovate update
+# (patch/digest dep bump, tekton task ref, dockerfile, or rpm-lockfile) and
+# all required checks passed, it adds approved/lgtm labels so the merge bot
+# can merge it automatically.
+#
+# Using workflow_run ensures this workflow has write permissions regardless
+# of whether the PR comes from a fork/bot.
+
+on:
+  workflow_run:
+    workflows: ["Tests", "Lint", "E2E Tests"]
+    types: [completed]
+
+jobs:
+  auto-approve:
+    name: Label approved if CI passed
+    runs-on: ubuntu-latest
+    # Only proceed when the triggering workflow was for a pull request
+    if: github.event.workflow_run.event == 'pull_request'
+    permissions:
+      pull-requests: write
+      issues: write
+      actions: read
+      checks: read
+      statuses: read
+
+    steps:
+      - name: Find PR and check eligibility
+        id: eligible
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # workflow_run provides the head SHA; find the associated PR
+          PR_NUMBER=$(gh api "repos/${{ github.repository }}/pulls" \
+            --jq ".[] | select(.head.sha == \"${{ github.event.workflow_run.head_sha }}\") | .number" \
+            | head -1)
+
+          if [[ -z "${PR_NUMBER}" ]]; then
+            echo "No open PR found for SHA ${{ github.event.workflow_run.head_sha }}"
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+          # Fetch all PR metadata in a single call
+          PR_DATA=$(gh pr view "${PR_NUMBER}" \
+            --repo "${{ github.repository }}" \
+            --json author,labels,title,headRefName)
+
+          AUTHOR=$(echo "${PR_DATA}" | jq -r '.author.login')
+          LABELS=$(echo "${PR_DATA}" | jq -r '.labels[].name')
+          PR_TITLE=$(echo "${PR_DATA}" | jq -r '.title')
+          PR_BRANCH=$(echo "${PR_DATA}" | jq -r '.headRefName')
+
+          # Must be from Renovate or Mintmaker
+          if [[ "${AUTHOR}" != "renovate[bot]" && "${AUTHOR}" != "red-hat-konflux[bot]" ]]; then
+            echo "PR author ${AUTHOR} is not a dependency bot, skipping"
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Must NOT already have approved label (idempotency)
+          if echo "${LABELS}" | grep -q "^approved$"; then
+            echo "PR already has approved label, skipping"
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Must be a low-risk update: patch/digest gomod, tekton, dockerfile, or rpm-lockfile
+          IS_PATCH=false
+          if echo "${LABELS}" | grep -q "^semver/patch$"; then
+            IS_PATCH=true
+          fi
+
+          # Check for non-gomod managers that we also auto-approve
+          IS_INFRA=false
+          if [[ "${PR_TITLE}" == *"update konflux references"* ]] || \
+             [[ "${PR_BRANCH}" == *"dockerfile"* && "${PR_TITLE}" != *"go-toolset"* ]] || \
+             [[ "${PR_BRANCH}" == *"rpm-lockfile"* ]]; then
+            IS_INFRA=true
+          fi
+
+          if [[ "${IS_PATCH}" != "true" && "${IS_INFRA}" != "true" ]]; then
+            echo "PR is not a patch bump or infra update, skipping"
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "PR #${PR_NUMBER} is eligible for auto-approve"
+          echo "eligible=true" >> "$GITHUB_OUTPUT"
+
+      - name: Check all CI checks passed
+        if: steps.eligible.outputs.eligible == 'true'
+        id: ci
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+
+          # Get all check runs in a single call and extract counts
+          CHECK_RUNS=$(gh api "repos/${{ github.repository }}/commits/${HEAD_SHA}/check-runs" \
+            --jq '.check_runs[] | select(.name != "Label approved if CI passed")')
+
+          FAILED_CHECKS=$(echo "${CHECK_RUNS}" | jq -s '[.[] | select(.conclusion != null and .conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral")] | length')
+          PENDING_CHECKS=$(echo "${CHECK_RUNS}" | jq -s '[.[] | select(.conclusion == null)] | length')
+
+          echo "Failed checks: ${FAILED_CHECKS}, Pending checks: ${PENDING_CHECKS}"
+
+          if [[ "${FAILED_CHECKS}" -gt 0 ]]; then
+            echo "Some checks failed, not approving"
+            echo "passed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "${PENDING_CHECKS}" -gt 0 ]]; then
+            echo "Some checks still pending, not approving yet (will re-run when they complete)"
+            echo "passed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "All checks passed"
+          echo "passed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Apply approved and lgtm labels
+        if: >-
+          steps.eligible.outputs.eligible == 'true' &&
+          steps.ci.outputs.passed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ steps.eligible.outputs.number }}"
+
+          # Create labels if they don't exist
+          for label in approved lgtm; do
+            gh label create "${label}" --repo "${{ github.repository }}" \
+              --color "0e8a16" --description "Auto-approved dependency update" \
+              --force 2>/dev/null || true
+          done
+
+          gh pr edit "${PR_NUMBER}" \
+            --repo "${{ github.repository }}" \
+            --add-label "approved,lgtm"
+
+          echo "Applied approved and lgtm labels to PR #${PR_NUMBER}"

--- a/.github/workflows/dep-semver-label.yaml
+++ b/.github/workflows/dep-semver-label.yaml
@@ -48,10 +48,22 @@ jobs:
           BUMP_TYPE=$(./hack/detect-semver-bump.sh /tmp/pr-body.md "${{ github.event.pull_request.title }}")
           echo "Detected bump type: ${BUMP_TYPE}"
 
-          # Map digest to patch for labeling purposes
+          # Map digest: gomod digests (pseudo-versions) have no semver guarantees,
+          # so treat them as minor to trigger impact analysis. Non-gomod digests
+          # (e.g. container images) are safe to treat as patch.
           LABEL_TYPE="${BUMP_TYPE}"
           if [[ "${LABEL_TYPE}" == "digest" ]]; then
-            LABEL_TYPE="patch"
+            PR_TITLE="${{ github.event.pull_request.title }}"
+            # Detect Go module digests by matching known Go module hosting domains.
+            # This avoids false positives on container image references like
+            # registry.access.redhat.com/ubi9 which also match generic domain/path patterns.
+            if echo "${PR_TITLE}" | grep -qP '(github\.com|k8s\.io|sigs\.k8s\.io|golang\.org|google\.golang\.org|go\.uber\.org|gopkg\.in)/'; then
+              LABEL_TYPE="minor"
+            elif echo "${PR_TITLE}" | grep -qiE '\bmodule\b'; then
+              LABEL_TYPE="minor"
+            else
+              LABEL_TYPE="patch"
+            fi
           fi
 
           if [[ "${LABEL_TYPE}" == "unknown" ]]; then

--- a/docs/dependency-policy.md
+++ b/docs/dependency-policy.md
@@ -15,43 +15,46 @@ Dependencies are classified using Renovate's native `matchDepTypes`:
 
 Every dependency PR is labeled with the semver bump type:
 
-- `semver/patch` — Patch or digest updates (e.g., 1.2.3 → 1.2.4). Bug fixes only, no new features or breaking changes per semver contract.
-- `semver/minor` — Minor updates (e.g., 1.2.0 → 1.3.0). New features, backwards-compatible.
+- `semver/patch` — Patch updates (e.g., 1.2.3 → 1.2.4). Bug fixes only, no new features or breaking changes per semver contract. Non-gomod digest updates (e.g., container images) are also labeled as patch.
+- `semver/minor` — Minor updates (e.g., 1.2.0 → 1.3.0). New features, backwards-compatible. **Gomod digest/pseudo-version bumps** (e.g., `v0.0.0-20250910...` → `v0.0.0-20260330...`) are also labeled as minor because pseudo-versions have no semver guarantees and may contain breaking changes.
 - `semver/major` — Major updates (e.g., 1.0.0 → 2.0.0). May contain breaking changes.
 
 ### Semver Label Fallback
 
 Semver labels are primarily applied by Renovate via `packageRules`. As a fallback, a GitHub Action workflow (`.github/workflows/dep-semver-label.yaml`) detects the bump type from the PR body/title and applies the label if Renovate hasn't. This handles edge cases like two-component docker tags (`v9.5` → `v9.7`) and digest-only updates.
 
-## Auto-merge Rules
+## Auto-approve Rules
 
 | Update Type | Direct | Transitive | Action |
 |-------------|--------|------------|--------|
-| Patch/digest | Auto-merge | Auto-merge | Merged automatically when CI passes |
+| Patch | Auto-approve | Auto-approve | `approved`/`lgtm` labels added after CI passes |
+| Gomod digest | Manual review | Manual review | Labeled `semver/minor` — pseudo-versions have no semver guarantees |
 | Minor | Manual review | Manual review | Requires human approval |
 | Major | Manual review | Manual review | Requires human approval |
-| Konflux references (Tekton tasks) | N/A | N/A | Auto-merge when CI passes |
-| Dockerfile updates | N/A | N/A | Auto-merge when CI passes |
+| Konflux references (Tekton tasks) | N/A | N/A | Auto-approve after CI passes |
+| Dockerfile updates | N/A | N/A | Auto-approve after CI passes |
 | Go toolchain (go-toolset) | N/A | N/A | **Manual review required** |
-| RPM lockfile updates | N/A | N/A | Auto-merge when CI passes |
+| RPM lockfile updates | N/A | N/A | Auto-approve after CI passes |
 
-Auto-merge uses GitHub's platform auto-merge (`platformAutomerge`), which requires all required status checks to pass before merging.
+Auto-approve is handled by a post-CI GitHub Actions workflow (`.github/workflows/auto-approve.yaml`). It triggers after the "Tests", "Lint", and "E2E Tests" workflows complete, verifies all check runs passed, and only then applies `approved` and `lgtm` labels. This ensures PRs with failing tests are never labeled as approved.
 
 ### Rationale
 
-- **Patch bumps** are low-risk by semver convention (bug fixes only). Combined with CI validation, auto-merging reduces review burden without meaningful risk.
+- **Patch bumps** are low-risk by semver convention (bug fixes only). Combined with CI validation, auto-approving reduces review burden without meaningful risk.
+- **Gomod digest/pseudo-version bumps** use `v0.0.0-timestamp-hash` versions with no semver guarantees. Breaking API changes have been observed in k8s.io pseudo-version bumps, so these require manual review with AI impact analysis.
 - **Minor/major bumps** may introduce new behavior or breaking changes and benefit from human review.
 - **Konflux reference updates** are digest-only updates to build pipeline task references — they are validated by the Tekton pipeline CI.
-- **Go toolchain updates** (`go-toolset` image) are excluded from auto-merge because they frequently require coordinated changes to build infrastructure (Tekton task images, Dockerfile base images) and have historically caused CI failures.
+- **Go toolchain updates** (`go-toolset` image) are excluded from auto-approve because they frequently require coordinated changes to build infrastructure (Tekton task images, Dockerfile base images) and have historically caused CI failures.
 
 ## PR Grouping
 
-Go module updates are grouped to reduce PR volume:
+Go module updates are individual PRs (no grouping) to allow independent merging and failure isolation. One failing update does not block other safe updates.
 
-- `go-modules patch` — All patch/digest bumps in one PR
-- `go-modules minor` — All minor bumps in one PR
-- Major bumps — Individual PRs per package (ungrouped)
-- `go-modules k8s` — Kubernetes-related packages (`k8s.io/*`, `sigs.k8s.io/controller-runtime`) grouped together for minor/major/digest updates
+- Patch bumps — Individual PRs per package
+- Digest bumps — Individual PRs per package
+- Minor bumps — Individual PRs per package
+- Major bumps — Individual PRs per package
+- `go-modules k8s` — Exception: Kubernetes-related packages (`k8s.io/*`, `sigs.k8s.io/controller-runtime`) are grouped together for minor/major/digest updates because they are tightly coupled and must be upgraded together
 
 ## Import Usage Comments
 
@@ -59,26 +62,26 @@ For PRs updating direct dependencies, a GitHub Action posts a comment listing wh
 
 ## Override Procedure
 
-To exclude a specific package from auto-merge, add a `packageRules` entry in `renovate.json`:
+To exclude a specific package from auto-approve, add a `packageRules` entry in `renovate.json` to force it to a non-patch label:
 
 ```json
 {
   "description": "Require manual review for package-name",
   "matchPackageNames": ["github.com/example/package-name"],
-  "automerge": false
+  "addLabels": ["semver/minor"]
 }
 ```
 
-Place this rule **after** the auto-merge rules so it takes precedence.
+This ensures the auto-approve workflow skips the PR since it only acts on `semver/patch` labels.
 
 ## Rollback Procedure
 
-If an auto-merged dependency update causes a regression:
+If an auto-approved dependency update causes a regression:
 
 1. **Revert the PR**: Create a revert PR for the problematic merge.
-2. **Disable auto-merge temporarily** (if needed): Set `automerge: false` on the relevant `packageRules` in `renovate.json`. This is a single-line change.
+2. **Disable auto-approve temporarily** (if needed): Disable the `auto-approve.yaml` workflow or add the package to the override list.
 3. **Investigate**: Determine if the issue is in the dependency or in our usage of it.
-4. **Re-enable**: Once resolved, remove the `automerge: false` override.
+4. **Re-enable**: Once resolved, remove the override.
 
 ## Configuration
 


### PR DESCRIPTION
The previous Renovate config had three issues observed in practice:

1. The "approved" and "lgtm" labels were applied at PR creation time, before any CI checks ran. This caused PRs with failing tests to be labeled as approved, misleading the merge bot.

2. Patch-version Go module bumps were grouped into a single PR. When one dependency in the group broke tests, all other safe upgrades were blocked from merging — defeating the goal of auto-merging low-risk updates.

3. The minimumReleaseAge of 3 days prevented green PRs from merging promptly, adding unnecessary delay with no clear benefit given that CI already validates the upgrades.

4. Tekton task reference updates always have the title "chore(deps): update konflux references", which is a more reliable signal than matching on branch name patterns.

Changes:
- Remove minimumReleaseAge so green PRs can merge without delay
- Remove groupName for gomod patch bumps so each gets its own PR
- Remove automerge and approved/lgtm/auto-merged labels from all Renovate package rules (gomod patch, tekton, dockerfile, rpm-lockfile)
- Add a new auto-approve workflow that triggers after CI completes and only applies approved/lgtm labels when all checks have passed
- Match tekton PRs by title instead of branch name

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

Contributes to: KFLUXINFRA-3008