### PR TITLE
Fix: set response.patch to nil when all patches are filtered out

### DIFF
--- a/internal/webhook/v1/pipelinerun_webhook.go
+++ b/internal/webhook/v1/pipelinerun_webhook.go
@@ -84,6 +84,7 @@ func (w *patchFilteringWebhook) Handle(ctx context.Context, req admission.Reques
 	resp.Patches = resp.Patches[:n]
 	if n == 0 {
 		resp.PatchType = nil
+		resp.Patch = nil
 	}
 	return resp
 }

--- a/internal/webhook/v1/pipelinerun_webhook_test.go
+++ b/internal/webhook/v1/pipelinerun_webhook_test.go
@@ -335,6 +335,24 @@ var minimalPipelineRunJSON = []byte(`{
 	}
 }`)
 
+// prePopulatedPipelineRunJSON is a raw  admission request. It has all the fields prepopulated
+// Webhook is not supposed apply any patch here
+var prePopulatedPipelineRunJSON = []byte(`{
+	"apiVersion": "tekton.dev/v1",
+	"kind": "PipelineRun",
+	"metadata": {
+		"name": "test-plr",
+		"namespace": "default",
+		"labels" : {
+			"kueue.x-k8s.io/queue-name": "test-queue"
+		}
+	},
+	"spec": {
+		"status" : "PipelineRunPending",
+		"pipelineRef": {"name": "test-pipeline"}
+	}
+}`)
+
 // fieldsWeNeverTouch lists spec/status fields the webhook should never patch.
 var fieldsWeNeverTouch = []string{
 	"taskRunTemplate",
@@ -366,9 +384,9 @@ var _ = Describe("Zero-value field leak (issue #319)", func() {
 	})
 
 	It("raw CustomDefaulter leaks zero-value struct fields into patches", func(ctx context.Context) {
+
 		defaulter, err := NewCustomDefaulter(cfgStore)
 		Expect(err).NotTo(HaveOccurred())
-
 		unfiltered := admission.WithCustomDefaulter(scheme, &tektondevv1.PipelineRun{}, defaulter)
 		resp := unfiltered.Handle(ctx, makeAdmissionRequest(minimalPipelineRunJSON))
 		Expect(resp.Allowed).To(BeTrue())
@@ -413,5 +431,23 @@ var _ = Describe("Zero-value field leak (issue #319)", func() {
 					fmt.Sprintf("patch at %s still contains '%s' after filtering", p.Path, field))
 			}
 		}
+	})
+
+	// This Test validates the case when PipelineRun Contains all the fields and Webhook is not expected to apply Any patch.
+	// In Such Scenario Handler webhook should set the Patch and PatchType to Nil
+	// Both these values should be sync otherwise Kubernetes will not be able to process the PipelineRun.
+	It("patchFilteringWebhook sets Patch and PatchType to nil when there is nothing to patch", func(ctx context.Context) {
+		defaulter, err := NewCustomDefaulter(cfgStore)
+		Expect(err).NotTo(HaveOccurred())
+
+		inner := admission.WithCustomDefaulter(scheme, &tektondevv1.PipelineRun{}, defaulter)
+		filtered := &patchFilteringWebhook{inner: inner}
+
+		resp := filtered.Handle(ctx, makeAdmissionRequest(prePopulatedPipelineRunJSON))
+
+		Expect(resp.Allowed).To(BeTrue())
+		Expect(resp.Patches).To(BeEmpty())
+		Expect(resp.Patch).To(BeNil())
+		Expect(resp.PatchType).To(BeNil())
 	})
 })


### PR DESCRIPTION
When webhook filters out all the patches then PatchType is set to nil but  there might be  Response.Patch is stil holding the value.

Setting the Response.Patch to nil will align the  response.Patch and Response.PatchType so calling validator do not fail