### PR TITLE
Add unit tests for controller and common packages

### DIFF
--- a/internal/controller/configmap_controller_test.go
+++ b/internal/controller/configmap_controller_test.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1 "github.com/konflux-ci/tekton-kueue/internal/webhook/v1"
+	"github.com/konflux-ci/tekton-kueue/pkg/common"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+var _ = Describe("ConfigMapReconciler", func() {
+	var (
+		reconciler *ConfigMapReconciler
+		store      *v1.ConfigStore
+		s          *runtime.Scheme
+		nsName     types.NamespacedName
+	)
+
+	BeforeEach(func() {
+		s = runtime.NewScheme()
+		Expect(clientgoscheme.AddToScheme(s)).To(Succeed())
+
+		store = &v1.ConfigStore{}
+		nsName = types.NamespacedName{
+			Name:      common.ConfigMapName,
+			Namespace: "tekton-kueue",
+		}
+	})
+
+	Describe("Reconcile", func() {
+		It("should return success when ConfigMap is not found", func(ctx context.Context) {
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(s).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(_ context.Context, _ client.WithWatch, key client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+						Expect(key).To(Equal(nsName))
+						return apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, key.Name)
+					},
+				}).
+				Build()
+			reconciler = &ConfigMapReconciler{Client: fakeClient, Store: store}
+
+			Expect(reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: nsName})).To(Equal(ctrl.Result{}))
+		})
+
+		It("should return error when Client.Get fails with a non-NotFound error", func(ctx context.Context) {
+			getErr := fmt.Errorf("connection refused")
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(s).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(_ context.Context, _ client.WithWatch, key client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+						Expect(key).To(Equal(nsName))
+						return getErr
+					},
+				}).
+				Build()
+			reconciler = &ConfigMapReconciler{Client: fakeClient, Store: store}
+
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: nsName})
+			Expect(err).To(MatchError("connection refused"))
+		})
+
+		It("should return success when ConfigMap exists but config key is missing", func(ctx context.Context) {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.ConfigMapName,
+					Namespace: "tekton-kueue",
+				},
+				Data: map[string]string{
+					"other-key": "some-value",
+				},
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(cm).Build()
+			reconciler = &ConfigMapReconciler{Client: fakeClient, Store: store}
+
+			Expect(reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: nsName})).To(Equal(ctrl.Result{}))
+		})
+
+		It("should requeue when config YAML is invalid", func(ctx context.Context) {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.ConfigMapName,
+					Namespace: "tekton-kueue",
+				},
+				Data: map[string]string{
+					common.ConfigKey: "invalid: yaml: [:",
+				},
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(cm).Build()
+			reconciler = &ConfigMapReconciler{Client: fakeClient, Store: store}
+
+			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: nsName})
+			Expect(err).To(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(10 * time.Second))
+		})
+
+		It("should requeue when config validation fails (empty queue name)", func(ctx context.Context) {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.ConfigMapName,
+					Namespace: "tekton-kueue",
+				},
+				Data: map[string]string{
+					common.ConfigKey: "multiKueueOverride: true",
+				},
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(cm).Build()
+			reconciler = &ConfigMapReconciler{Client: fakeClient, Store: store}
+
+			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: nsName})
+			Expect(err).To(MatchError(ContainSubstring("queue name")))
+			Expect(result.RequeueAfter).To(Equal(10 * time.Second))
+		})
+
+		It("should update the store successfully with valid config", func(ctx context.Context) {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.ConfigMapName,
+					Namespace: "tekton-kueue",
+				},
+				Data: map[string]string{
+					common.ConfigKey: "queueName: test-queue\nmultiKueueOverride: false",
+				},
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(cm).Build()
+			reconciler = &ConfigMapReconciler{Client: fakeClient, Store: store}
+
+			Expect(reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: nsName})).To(Equal(ctrl.Result{}))
+
+			cfg, mutators := store.GetConfigAndMutators()
+			Expect(cfg).NotTo(BeNil())
+			Expect(cfg.QueueName).To(Equal("test-queue"))
+			Expect(cfg.MultiKueueOverride).To(BeFalse())
+			Expect(mutators).To(BeEmpty())
+		})
+	})
+})

--- a/internal/controller/pipelinerun_controller.go
+++ b/internal/controller/pipelinerun_controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -18,6 +19,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/ptr"
 	kapi "knative.dev/pkg/apis"
 
 	kueueconfig "sigs.k8s.io/kueue/apis/config/v1beta1"
@@ -143,7 +145,10 @@ func (p *PipelineRun) Object() client.Object {
 
 // PodSets implements jobframework.GenericJob.
 func (p *PipelineRun) PodSets() ([]kueue.PodSet, error) {
-	requests := p.resourcesRequests()
+	requests, err := p.resourcesRequests()
+	if err != nil {
+		return nil, err
+	}
 
 	return []kueue.PodSet{
 		{
@@ -177,22 +182,48 @@ func (p *PipelineRun) PodSets() ([]kueue.PodSet, error) {
 // By default, a resource which indicates that the workload requires 1
 // PipelineRun will be added. This is useful for controlling the number
 // of PipelineRuns that can be executed concurrently.
-//
-// WARNING: Annotations are not validated and a panic will
-// happen if they can not be parsed as `resource.Quantity`.
-func (p *PipelineRun) resourcesRequests() corev1.ResourceList {
+func (p *PipelineRun) resourcesRequests() (corev1.ResourceList, error) {
 	requests := corev1.ResourceList{
 		ResourcePipelineRunCount: resource.MustParse("1"),
 	}
 
 	for k, v := range p.GetAnnotations() {
-		if t := strings.TrimPrefix(k, annotationResourcesRequests); t != k {
-			// TODO(@filariow): how to properly validate this?
-			requests[corev1.ResourceName(t)] = resource.MustParse(v)
+		n, q, err := p.parseResourcesRequestsAnnotation(k, v)
+		switch {
+		case err != nil:
+			return nil, err
+		case n != nil && q != nil:
+			requests[*n] = *q
 		}
 	}
 
-	return requests
+	return requests, nil
+}
+
+// parseResourcesRequestsAnnotation checks if an annotation is a ResourcesRequests one.
+// It validates the extracted key and value. If the annotation is invalid the PipelineRun can not
+// be correctly processed and it needs to be fixed. To avoid a reconciliation loop an
+// UnretryableError is returned. This will tell Kueue's reconciler to avoid reconciling the
+// PipelineRun at current state again. If a new event on the PipelineRun occurs, a new
+// reconciliation will start.
+func (p *PipelineRun) parseResourcesRequestsAnnotation(k, v string) (*corev1.ResourceName, *resource.Quantity, error) {
+	t, ok := strings.CutPrefix(k, annotationResourcesRequests)
+	if !ok {
+		return nil, nil, nil
+	}
+
+	if t == "" {
+		return nil, nil, jobframework.UnretryableError(
+			fmt.Sprintf("empty resource name in annotation %s", k))
+	}
+
+	q, err := resource.ParseQuantity(v)
+	if err != nil {
+		return nil, nil, jobframework.UnretryableError(
+			fmt.Sprintf("invalid resource quantity in annotation %s=%q: %v", k, v, err))
+	}
+
+	return ptr.To(corev1.ResourceName(t)), &q, nil
 }
 
 // PodsReady implements jobframework.GenericJob.

--- a/internal/controller/pipelinerun_controller_test.go
+++ b/internal/controller/pipelinerun_controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025.
+Copyright 2026.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,16 +17,494 @@ limitations under the License.
 package controller
 
 import (
+	"context"
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	tekv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kapi "knative.dev/pkg/apis"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/podset"
 )
 
-var _ = Describe("PipelineRun Controller", func() {
-	Context("When reconciling a resource", func() {
+func newTestPipelineRun(opts ...func(*tekv1.PipelineRun)) *PipelineRun {
+	plr := &tekv1.PipelineRun{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: tekv1.SchemeGroupVersion.String(),
+			Kind:       "PipelineRun",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-plr",
+			Namespace: "default",
+		},
+	}
+	for _, o := range opts {
+		o(plr)
+	}
+	return (*PipelineRun)(plr)
+}
 
-		It("should successfully reconcile the resource", func() {
+var _ = Describe("PipelineRun", func() {
 
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+	Describe("GVK", func() {
+		It("should return the PipelineRun GroupVersionKind", func() {
+			p := newTestPipelineRun()
+			gvk := p.GVK()
+			Expect(gvk.Group).To(Equal(tekv1.SchemeGroupVersion.Group))
+			Expect(gvk.Version).To(Equal(tekv1.SchemeGroupVersion.Version))
+			Expect(gvk.Kind).To(Equal("PipelineRun"))
+		})
+	})
+
+	Describe("IsActive", func() {
+		It("should return false when PipelineRun has not started", func() {
+			p := newTestPipelineRun()
+			Expect(p.IsActive()).To(BeFalse())
+		})
+
+		It("should return true when PipelineRun has started", func() {
+			now := metav1.Now()
+			p := newTestPipelineRun(func(plr *tekv1.PipelineRun) {
+				plr.Status.StartTime = &now
+			})
+			Expect(p.IsActive()).To(BeTrue())
+		})
+	})
+
+	Describe("IsSuspended", func() {
+		It("should return false when status is empty", func() {
+			p := newTestPipelineRun()
+			Expect(p.IsSuspended()).To(BeFalse())
+		})
+
+		It("should return true when status is Pending", func() {
+			p := newTestPipelineRun(func(plr *tekv1.PipelineRun) {
+				plr.Spec.Status = tekv1.PipelineRunSpecStatusPending
+			})
+			Expect(p.IsSuspended()).To(BeTrue())
+		})
+
+		It("should return false when status is StoppedRunFinally", func() {
+			p := newTestPipelineRun(func(plr *tekv1.PipelineRun) {
+				plr.Spec.Status = tekv1.PipelineRunSpecStatusStoppedRunFinally
+			})
+			Expect(p.IsSuspended()).To(BeFalse())
+		})
+	})
+
+	Describe("Object", func() {
+		It("should return the underlying PipelineRun as client.Object", func() {
+			p := newTestPipelineRun()
+			obj := p.Object()
+			Expect(obj).NotTo(BeNil())
+			Expect(obj.GetName()).To(Equal("test-plr"))
+			Expect(obj.GetNamespace()).To(Equal("default"))
+		})
+	})
+
+	Describe("PodsReady", func() {
+		It("should panic because it should not be called", func() {
+			p := newTestPipelineRun()
+			Expect(func() { p.PodsReady() }).To(PanicWith("pods ready shouldn't be called"))
+		})
+	})
+
+	Describe("RestorePodSetsInfo", func() {
+		It("should return false with nil input", func() {
+			p := newTestPipelineRun()
+			Expect(p.RestorePodSetsInfo(nil)).To(BeFalse())
+		})
+
+		It("should return false with non-empty input", func() {
+			p := newTestPipelineRun()
+			Expect(p.RestorePodSetsInfo([]podset.PodSetInfo{{}})).To(BeFalse())
+		})
+	})
+
+	DescribeTable("RunWithPodSetsInfo should clear Spec.Status regardless of prior value",
+		func(initialStatus string) {
+			p := newTestPipelineRun(func(plr *tekv1.PipelineRun) {
+				plr.Spec.Status = tekv1.PipelineRunSpecStatus(initialStatus)
+			})
+			Expect(p.RunWithPodSetsInfo(nil)).To(Succeed())
+			Expect(p.Spec.Status).To(BeEmpty())
+		},
+		Entry("when status is empty", ""),
+		Entry("when status is Pending", string(tekv1.PipelineRunSpecStatusPending)),
+		Entry("when status is StoppedRunFinally", string(tekv1.PipelineRunSpecStatusStoppedRunFinally)),
+	)
+
+	Describe("Suspend", func() {
+		It("should not change the PipelineRun state (no-op)", func() {
+			p := newTestPipelineRun(func(plr *tekv1.PipelineRun) {
+				plr.Spec.Status = ""
+			})
+			p.Suspend()
+			// Suspend is a no-op because JobWithCustomStop is implemented
+			Expect(p.Spec.Status).To(BeEmpty())
+		})
+	})
+
+	Describe("Finished", func() {
+		It("should return empty values when no condition is set", func() {
+			p := newTestPipelineRun()
+			msg, success, finished := p.Finished()
+			Expect(msg).To(BeEmpty())
+			Expect(success).To(BeFalse())
+			Expect(finished).To(BeFalse())
+		})
+
+		It("should report success when reason is Successful", func() {
+			p := newTestPipelineRun(func(plr *tekv1.PipelineRun) {
+				plr.Status.Conditions = []kapi.Condition{
+					{
+						Type:    kapi.ConditionSucceeded,
+						Status:  corev1.ConditionTrue,
+						Reason:  tekv1.PipelineRunReasonSuccessful.String(),
+						Message: "All tasks completed successfully",
+					},
+				}
+			})
+			msg, success, finished := p.Finished()
+			Expect(msg).To(Equal("All tasks completed successfully"))
+			Expect(success).To(BeTrue())
+			Expect(finished).To(BeTrue())
+		})
+
+		It("should report success when reason is Completed", func() {
+			p := newTestPipelineRun(func(plr *tekv1.PipelineRun) {
+				plr.Status.Conditions = []kapi.Condition{
+					{
+						Type:    kapi.ConditionSucceeded,
+						Status:  corev1.ConditionTrue,
+						Reason:  tekv1.PipelineRunReasonCompleted.String(),
+						Message: "Pipeline completed",
+					},
+				}
+			})
+			msg, success, finished := p.Finished()
+			Expect(msg).To(Equal("Pipeline completed"))
+			Expect(success).To(BeTrue())
+			Expect(finished).To(BeTrue())
+		})
+
+		It("should report failure when PipelineRun has failed", func() {
+			p := newTestPipelineRun(func(plr *tekv1.PipelineRun) {
+				plr.Status.Conditions = []kapi.Condition{
+					{
+						Type:    kapi.ConditionSucceeded,
+						Status:  corev1.ConditionFalse,
+						Reason:  "Failed",
+						Message: "Task my-task failed",
+					},
+				}
+			})
+			msg, success, finished := p.Finished()
+			Expect(msg).To(Equal("Task my-task failed"))
+			Expect(success).To(BeFalse())
+			Expect(finished).To(BeTrue())
+		})
+
+		It("should report not finished when condition status is Unknown", func() {
+			p := newTestPipelineRun(func(plr *tekv1.PipelineRun) {
+				plr.Status.Conditions = []kapi.Condition{
+					{
+						Type:    kapi.ConditionSucceeded,
+						Status:  corev1.ConditionUnknown,
+						Reason:  "Running",
+						Message: "Tasks are still running",
+					},
+				}
+			})
+			msg, success, finished := p.Finished()
+			Expect(msg).To(Equal("Tasks are still running"))
+			Expect(success).To(BeFalse())
+			Expect(finished).To(BeFalse())
+		})
+	})
+
+	Describe("resourcesRequests", func() {
+		It("should return only the default pipelinerun count when no annotations are set", func() {
+			p := newTestPipelineRun()
+			requests, err := p.resourcesRequests()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(requests).To(And(
+				HaveLen(1),
+				HaveKeyWithValue(
+					corev1.ResourceName(ResourcePipelineRunCount),
+					resource.MustParse("1"),
+				),
+			))
+		})
+
+		It("should ignore annotations that do not match the resource requests prefix", func() {
+			p := newTestPipelineRun(func(plr *tekv1.PipelineRun) {
+				plr.Annotations = map[string]string{
+					"some-other-annotation":       "value",
+					"kueue.konflux-ci.dev/other":  "value",
+					"kueue.konflux-ci.dev/config": "value",
+				}
+			})
+			requests, err := p.resourcesRequests()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(requests).To(And(
+				HaveLen(1),
+				HaveKey(corev1.ResourceName(ResourcePipelineRunCount)),
+			))
+		})
+
+		It("should parse cpu and memory resource annotations", func() {
+			p := newTestPipelineRun(func(plr *tekv1.PipelineRun) {
+				plr.Annotations = map[string]string{
+					"kueue.konflux-ci.dev/requests-cpu":    "500m",
+					"kueue.konflux-ci.dev/requests-memory": "256Mi",
+				}
+			})
+			requests, err := p.resourcesRequests()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(requests).To(And(
+				HaveLen(3),
+				HaveKeyWithValue(corev1.ResourceName("cpu"), resource.MustParse("500m")),
+				HaveKeyWithValue(corev1.ResourceName("memory"), resource.MustParse("256Mi")),
+				HaveKeyWithValue(corev1.ResourceName(ResourcePipelineRunCount), resource.MustParse("1")),
+			))
+		})
+
+		It("should parse ephemeral-storage and storage annotations", func() {
+			p := newTestPipelineRun(func(plr *tekv1.PipelineRun) {
+				plr.Annotations = map[string]string{
+					"kueue.konflux-ci.dev/requests-ephemeral-storage": "10Gi",
+					"kueue.konflux-ci.dev/requests-storage":           "50Gi",
+				}
+			})
+			requests, err := p.resourcesRequests()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(requests).To(And(
+				HaveLen(3),
+				HaveKeyWithValue(corev1.ResourceName("ephemeral-storage"), resource.MustParse("10Gi")),
+				HaveKeyWithValue(corev1.ResourceName("storage"), resource.MustParse("50Gi")),
+			))
+		})
+
+		It("should include only matching annotations when mixed with unrelated ones", func() {
+			p := newTestPipelineRun(func(plr *tekv1.PipelineRun) {
+				plr.Annotations = map[string]string{
+					"kueue.konflux-ci.dev/requests-cpu": "2",
+					"unrelated/annotation":              "ignored",
+					"kueue.konflux-ci.dev/queue-name":   "also-ignored",
+				}
+			})
+			requests, err := p.resourcesRequests()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(requests).To(And(
+				HaveLen(2),
+				HaveKeyWithValue(corev1.ResourceName("cpu"), resource.MustParse("2")),
+				HaveKeyWithValue(corev1.ResourceName(ResourcePipelineRunCount), resource.MustParse("1")),
+			))
+		})
+
+		It("should return unretryable error when annotation key has empty resource name", func() {
+			p := newTestPipelineRun(func(plr *tekv1.PipelineRun) {
+				plr.Annotations = map[string]string{
+					"kueue.konflux-ci.dev/requests-": "500m",
+				}
+			})
+			requests, err := p.resourcesRequests()
+			Expect(err).To(And(
+				MatchError(ContainSubstring("empty resource name")),
+				Satisfy(jobframework.IsUnretryableError),
+			))
+			Expect(requests).To(BeNil())
+		})
+
+		It("should return unretryable error when annotation value is not a valid resource.Quantity", func() {
+			p := newTestPipelineRun(func(plr *tekv1.PipelineRun) {
+				plr.Annotations = map[string]string{
+					"kueue.konflux-ci.dev/requests-cpu": "not-a-quantity",
+				}
+			})
+			requests, err := p.resourcesRequests()
+			Expect(err).To(And(
+				MatchError(And(
+					ContainSubstring("invalid resource quantity"),
+					ContainSubstring("not-a-quantity"),
+				)),
+				Satisfy(jobframework.IsUnretryableError),
+			))
+			Expect(requests).To(BeNil())
+		})
+	})
+
+	Describe("PodSets", func() {
+		It("should return a single pod set with the correct structure", func() {
+			p := newTestPipelineRun()
+			podSets, err := p.PodSets()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(podSets).To(HaveLen(1))
+
+			ps := podSets[0]
+			Expect(string(ps.Name)).To(Equal("pod-set-1"))
+			Expect(ps.Count).To(Equal(int32(1)))
+
+			containers := ps.Template.Spec.Containers
+			Expect(containers).To(HaveLen(1))
+			Expect(containers[0].Name).To(Equal("dummy"))
+			Expect(containers[0].Image).To(Equal("dummy"))
+		})
+
+		It("should include resource requests from annotations in the pod set", func() {
+			p := newTestPipelineRun(func(plr *tekv1.PipelineRun) {
+				plr.Annotations = map[string]string{
+					"kueue.konflux-ci.dev/requests-cpu":    "4",
+					"kueue.konflux-ci.dev/requests-memory": "8Gi",
+				}
+			})
+			podSets, err := p.PodSets()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(podSets).To(HaveLen(1))
+			Expect(podSets[0].Template.Spec.Containers).To(HaveLen(1))
+
+			requests := podSets[0].Template.Spec.Containers[0].Resources.Requests
+			Expect(requests).To(And(
+				HaveKeyWithValue(corev1.ResourceName("cpu"), resource.MustParse("4")),
+				HaveKeyWithValue(corev1.ResourceName("memory"), resource.MustParse("8Gi")),
+				HaveKeyWithValue(corev1.ResourceName(ResourcePipelineRunCount), resource.MustParse("1")),
+			))
+		})
+
+		It("should return an unretryable error when annotation has invalid resource quantity", func() {
+			p := newTestPipelineRun(func(plr *tekv1.PipelineRun) {
+				plr.Annotations = map[string]string{
+					"kueue.konflux-ci.dev/requests-cpu": "not-a-quantity",
+				}
+			})
+			_, err := p.PodSets()
+			Expect(err).To(And(
+				MatchError(ContainSubstring("invalid resource quantity")),
+				Satisfy(jobframework.IsUnretryableError),
+			))
+		})
+	})
+
+	Describe("Stop", func() {
+		var s *runtime.Scheme
+
+		BeforeEach(func() {
+			s = runtime.NewScheme()
+			Expect(tekv1.AddToScheme(s)).To(Succeed())
+		})
+
+		It("should return false when PipelineRun is already done", func(ctx context.Context) {
+			p := newTestPipelineRun(func(plr *tekv1.PipelineRun) {
+				plr.Status.Conditions = []kapi.Condition{
+					{
+						Type:   kapi.ConditionSucceeded,
+						Status: corev1.ConditionTrue,
+					},
+				}
+			})
+
+			fakeClient := fake.NewClientBuilder().WithScheme(s).Build()
+			stopped, err := p.Stop(ctx, fakeClient, nil, jobframework.StopReasonWorkloadEvicted, "evicted")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stopped).To(BeFalse())
+		})
+
+		It("should return false when PipelineRun is done with failure", func(ctx context.Context) {
+			p := newTestPipelineRun(func(plr *tekv1.PipelineRun) {
+				plr.Status.Conditions = []kapi.Condition{
+					{
+						Type:   kapi.ConditionSucceeded,
+						Status: corev1.ConditionFalse,
+					},
+				}
+			})
+
+			fakeClient := fake.NewClientBuilder().WithScheme(s).Build()
+			stopped, err := p.Stop(ctx, fakeClient, nil, jobframework.StopReasonWorkloadEvicted, "evicted")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stopped).To(BeFalse())
+		})
+
+		It("should return false when PipelineRun status is not pending or running", func(ctx context.Context) {
+			p := newTestPipelineRun(func(plr *tekv1.PipelineRun) {
+				plr.Spec.Status = tekv1.PipelineRunSpecStatusStoppedRunFinally
+			})
+
+			fakeClient := fake.NewClientBuilder().WithScheme(s).Build()
+			stopped, err := p.Stop(ctx, fakeClient, nil, jobframework.StopReasonWorkloadEvicted, "evicted")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stopped).To(BeFalse())
+		})
+
+		It("should stop a running PipelineRun with empty status", func(ctx context.Context) {
+			p := newTestPipelineRun(func(plr *tekv1.PipelineRun) {
+				plr.Spec.Status = ""
+			})
+			tekPlr := (*tekv1.PipelineRun)(p)
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(s).
+				WithObjects(tekPlr).
+				Build()
+
+			stopped, err := p.Stop(ctx, fakeClient, nil, jobframework.StopReasonWorkloadEvicted, "evicted")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stopped).To(BeTrue())
+
+			var updated tekv1.PipelineRun
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(tekPlr), &updated)).To(Succeed())
+			Expect(string(updated.Spec.Status)).To(Equal(string(tekv1.PipelineRunSpecStatusStoppedRunFinally)))
+		})
+
+		It("should stop a pending PipelineRun", func(ctx context.Context) {
+			p := newTestPipelineRun(func(plr *tekv1.PipelineRun) {
+				plr.Spec.Status = tekv1.PipelineRunSpecStatusPending
+			})
+			tekPlr := (*tekv1.PipelineRun)(p)
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(s).
+				WithObjects(tekPlr).
+				Build()
+
+			stopped, err := p.Stop(ctx, fakeClient, nil, jobframework.StopReasonWorkloadEvicted, "evicted")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stopped).To(BeTrue())
+
+			var updated tekv1.PipelineRun
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(tekPlr), &updated)).To(Succeed())
+			Expect(string(updated.Spec.Status)).To(Equal(string(tekv1.PipelineRunSpecStatusStoppedRunFinally)))
+		})
+
+		It("should return error when the patch fails", func(ctx context.Context) {
+			p := newTestPipelineRun(func(plr *tekv1.PipelineRun) {
+				plr.Spec.Status = ""
+			})
+			tekPlr := (*tekv1.PipelineRun)(p)
+
+			patchErr := fmt.Errorf("server unavailable")
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(s).
+				WithObjects(tekPlr).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(_ context.Context, _ client.WithWatch, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+						return patchErr
+					},
+				}).
+				Build()
+
+			stopped, err := p.Stop(ctx, fakeClient, nil, jobframework.StopReasonWorkloadEvicted, "evicted")
+			Expect(err).To(MatchError("server unavailable"))
+			Expect(stopped).To(BeFalse())
 		})
 	})
 })

--- a/internal/webhook/v1/config_store_test.go
+++ b/internal/webhook/v1/config_store_test.go
@@ -21,6 +21,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/konflux-ci/tekton-kueue/internal/cel"
 )
 
 var _ = Describe("Config Store ", func() {
@@ -28,8 +30,7 @@ var _ = Describe("Config Store ", func() {
 		It("When QueueName is Set", func(ctx context.Context) {
 			configData := "queueName: test-queue"
 			cfgStore := &ConfigStore{}
-			err := cfgStore.Update([]byte(configData))
-			Expect(err).NotTo(HaveOccurred())
+			Expect(cfgStore.Update([]byte(configData))).To(Succeed())
 
 			cfg, mutators := cfgStore.GetConfigAndMutators()
 			Expect(mutators).To(BeEmpty())
@@ -49,8 +50,7 @@ var _ = Describe("Config Store ", func() {
 		It("When MultiKueueOverride is Set", func(ctx context.Context) {
 			configData := "queueName: test-queue\nmultiKueueOverride: true "
 			cfgStore := &ConfigStore{}
-			err := cfgStore.Update([]byte(configData))
-			Expect(err).NotTo(HaveOccurred())
+			Expect(cfgStore.Update([]byte(configData))).To(Succeed())
 
 			cfg, mutators := cfgStore.GetConfigAndMutators()
 			Expect(mutators).To(BeEmpty())
@@ -62,8 +62,7 @@ var _ = Describe("Config Store ", func() {
 		It("When MultiKueueOverride is not Set", func(ctx context.Context) {
 			configData := "queueName: test-queue"
 			cfgStore := &ConfigStore{}
-			err := cfgStore.Update([]byte(configData))
-			Expect(err).NotTo(HaveOccurred())
+			Expect(cfgStore.Update([]byte(configData))).To(Succeed())
 
 			cfg, mutators := cfgStore.GetConfigAndMutators()
 			Expect(mutators).To(BeEmpty())
@@ -77,8 +76,7 @@ var _ = Describe("Config Store ", func() {
 		configData := "queueName: pipelines-queue\ncel:\n  expressions:\n    - priority(\"tekton-kueue-default\")\n"
 		It("When CEL is set", func(ctx context.Context) {
 			cfgStore := &ConfigStore{}
-			err := cfgStore.Update([]byte(configData))
-			Expect(err).NotTo(HaveOccurred())
+			Expect(cfgStore.Update([]byte(configData))).To(Succeed())
 			cfg, mutators := cfgStore.GetConfigAndMutators()
 			Expect(mutators).NotTo(BeEmpty())
 			Expect(cfg.QueueName).To(Equal("pipelines-queue"))
@@ -90,6 +88,16 @@ var _ = Describe("Config Store ", func() {
 			cfgStore := &ConfigStore{}
 			err := cfgStore.Update([]byte(configData))
 			Expect(err).To(HaveOccurred())
+		})
+		It("should create CEL mutators for valid expressions", func(ctx context.Context) {
+			configData := "queueName: test-queue\ncel:\n  expressions:\n    - annotation(\"test-key\", \"test-value\")\n"
+			cfgStore := &ConfigStore{}
+			Expect(cfgStore.Update([]byte(configData))).To(Succeed())
+
+			cfg, mutators := cfgStore.GetConfigAndMutators()
+			Expect(cfg.QueueName).To(Equal("test-queue"))
+			Expect(mutators).To(HaveLen(1))
+			Expect(mutators[0]).To(BeAssignableToTypeOf(&cel.CELMutator{}))
 		})
 	})
 

--- a/pkg/common/common_utils.go
+++ b/pkg/common/common_utils.go
@@ -1,17 +1,21 @@
 package common
 
 import (
-	"errors"
+	"fmt"
 	"os"
+	"strings"
 )
 
 const namespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 
 func GetCurrentNamespace() (string, error) {
-	bytes, err := os.ReadFile(namespaceFile)
+	return readNamespace(namespaceFile)
+}
+
+func readNamespace(path string) (string, error) {
+	bytes, err := os.ReadFile(path)
 	if err != nil {
-		return "", errors.New("not able to read  namespace file: " + namespaceFile)
+		return "", fmt.Errorf("not able to read namespace file %s: %w", path, err)
 	}
-	namespace := string(bytes)
-	return namespace, nil
+	return strings.TrimSpace(string(bytes)), nil
 }

--- a/pkg/common/common_utils_test.go
+++ b/pkg/common/common_utils_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("readNamespace", func() {
+	It("should return namespace from file", func() {
+		tmpFile := filepath.Join(GinkgoT().TempDir(), "namespace")
+		Expect(os.WriteFile(tmpFile, []byte("test-namespace"), 0644)).To(Succeed())
+
+		Expect(readNamespace(tmpFile)).To(Equal("test-namespace"))
+	})
+
+	It("should trim whitespace and newlines from namespace", func() {
+		tmpFile := filepath.Join(GinkgoT().TempDir(), "namespace")
+		Expect(os.WriteFile(tmpFile, []byte("test-namespace\n"), 0644)).To(Succeed())
+
+		Expect(readNamespace(tmpFile)).To(Equal("test-namespace"))
+	})
+
+	It("should return error when file does not exist", func() {
+		ns, err := readNamespace("/nonexistent/path/namespace")
+		Expect(err).To(MatchError(ContainSubstring("not able to read namespace file")))
+		Expect(ns).To(BeEmpty())
+	})
+})

--- a/pkg/common/suite_test.go
+++ b/pkg/common/suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCommon(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Common Suite")
+}


### PR DESCRIPTION
Add unit tests covering all logical branches for:

- PipelineRun controller methods (GVK, IsActive, IsSuspended, Object,
  PodsReady, RestorePodSetsInfo, RunWithPodSetsInfo, Suspend, Finished,
  PodSets, resourcesRequests, Stop) with fake client and interceptors
- ConfigMapReconciler.Reconcile (not found, get error, missing key,
  invalid YAML, validation failure, success, CEL mutators)
- GetCurrentNamespace (success and file-not-found paths)
- Add an internal readNamespace(path) function that tests call directly.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

COntributes to: KFLUXINFRA-3247