### PR TITLE
accept QPS and Burst from flags

### DIFF
--- a/cmd/cmd_suite_test.go
+++ b/cmd/cmd_suite_test.go
@@ -1,4 +1,4 @@
-package main_test
+package main
 
 import (
 	"testing"

--- a/cmd/cmd_suite_test.go
+++ b/cmd/cmd_suite_test.go
@@ -1,0 +1,13 @@
+package main_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCmd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cmd Suite")
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -77,6 +78,8 @@ type SharedFlags struct {
 	ProbeAddr       string
 	EnableHTTP2     bool
 	ZapOptions      *zap.Options
+	QPS             float64
+	Burst           int
 }
 
 func (s *SharedFlags) AddFlags(fs *flag.FlagSet) {
@@ -93,6 +96,8 @@ func (s *SharedFlags) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&s.ProbeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	fs.BoolVar(&s.EnableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
+	fs.Float64Var(&s.QPS, "qps", 0, "The Kubernetes API Client's QPS value")
+	fs.IntVar(&s.Burst, "burst", 0, "The Kubernetes API Client's Burst value")
 
 	s.ZapOptions = &zap.Options{
 		Development: true,
@@ -204,7 +209,20 @@ func runController(args []string) {
 		setupLog.Info("Leader election disabled")
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	cfg := ctrl.GetConfigOrDie()
+	// if Burst is set to 0, controller-runtime Client's default is used
+	cfg.Burst = controllerFlags.Burst
+	// ensure the provided value is a safe float32. If it's not, we set 0 and the
+	// controller-runtime's Client will use its default value.
+	qps, ok := safeFloat64ToFloat32OrDefault(controllerFlags.QPS, 0)
+	if !ok {
+		setupLog.
+			WithValues("provided-qps", controllerFlags.QPS, "used-qps", qps).
+			Info("provided QPS value is not a valid float32, using default")
+	}
+	cfg.QPS = qps
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
 		HealthProbeBindAddress: controllerFlags.ProbeAddr,
@@ -271,7 +289,20 @@ func runWebhook(args []string) {
 		setupLog.Error(err, "Exiting")
 		os.Exit(1)
 	}
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	cfg := ctrl.GetConfigOrDie()
+	// if Burst is set to 0, controller-runtime Client's default is used
+	cfg.Burst = webhookFlags.Burst
+	// ensure the provided value is a safe float32. If it's not, we set 0 and the
+	// controller-runtime's Client will use its default value.
+	qps, ok := safeFloat64ToFloat32OrDefault(webhookFlags.QPS, 0)
+	if !ok {
+		setupLog.
+			WithValues("provided-qps", webhookFlags.QPS, "used-qps", qps).
+			Info("provided QPS value is not a valid float32, using default")
+	}
+	cfg.QPS = qps
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
 		HealthProbeBindAddress: webhookFlags.ProbeAddr,
@@ -317,6 +348,13 @@ func runWebhook(args []string) {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+}
+
+func safeFloat64ToFloat32OrDefault(v float64, d float32) (float32, bool) {
+	if math.IsInf(v, 0) || math.IsNaN(v) {
+		return d, false
+	}
+	return float32(v), true
 }
 
 func runMutate(args []string) {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -351,7 +351,7 @@ func runWebhook(args []string) {
 }
 
 func safeFloat64ToFloat32OrZero(v float64) (float32, bool) {
-	if v < -math.MaxFloat32 || v > math.MaxFloat32 {
+	if math.IsNaN(v) || math.IsInf(v, 0) || v < -math.MaxFloat32 || v > math.MaxFloat32 {
 		return 0, false
 	}
 	return float32(v), true

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -351,7 +351,7 @@ func runWebhook(args []string) {
 }
 
 func safeFloat64ToFloat32OrDefault(v float64, d float32) (float32, bool) {
-	if math.IsInf(v, 0) || math.IsNaN(v) {
+	if v < -math.MaxFloat32 || v > math.MaxFloat32 {
 		return d, false
 	}
 	return float32(v), true

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -214,7 +214,7 @@ func runController(args []string) {
 	cfg.Burst = controllerFlags.Burst
 	// ensure the provided value is a safe float32. If it's not, we set 0 and the
 	// controller-runtime's Client will use its default value.
-	qps, ok := safeFloat64ToFloat32OrDefault(controllerFlags.QPS, 0)
+	qps, ok := safeFloat64ToFloat32OrZero(controllerFlags.QPS)
 	if !ok {
 		setupLog.
 			WithValues("provided-qps", controllerFlags.QPS, "used-qps", qps).
@@ -294,7 +294,7 @@ func runWebhook(args []string) {
 	cfg.Burst = webhookFlags.Burst
 	// ensure the provided value is a safe float32. If it's not, we set 0 and the
 	// controller-runtime's Client will use its default value.
-	qps, ok := safeFloat64ToFloat32OrDefault(webhookFlags.QPS, 0)
+	qps, ok := safeFloat64ToFloat32OrZero(webhookFlags.QPS)
 	if !ok {
 		setupLog.
 			WithValues("provided-qps", webhookFlags.QPS, "used-qps", qps).
@@ -350,9 +350,9 @@ func runWebhook(args []string) {
 	}
 }
 
-func safeFloat64ToFloat32OrDefault(v float64, d float32) (float32, bool) {
+func safeFloat64ToFloat32OrZero(v float64) (float32, bool) {
 	if v < -math.MaxFloat32 || v > math.MaxFloat32 {
-		return d, false
+		return 0, false
 	}
 	return float32(v), true
 }

--- a/cmd/main_ginkgo_test.go
+++ b/cmd/main_ginkgo_test.go
@@ -10,7 +10,7 @@ import (
 var _ = Describe("safeFloat64ToFloat32OrDefault", func() {
 	DescribeTable("converts valid float32 values",
 		func(v float64, e float32) {
-			a, ok := safeFloat64ToFloat32OrDefault(v, 0)
+			a, ok := safeFloat64ToFloat32OrZero(v)
 			Expect(ok).To(BeTrue())
 			Expect(a).To(Equal(e))
 		},
@@ -25,11 +25,9 @@ var _ = Describe("safeFloat64ToFloat32OrDefault", func() {
 
 	DescribeTable("returns default value if provided value is not a valid float32",
 		func(v float64) {
-			d := float32(0)
-
-			a, ok := safeFloat64ToFloat32OrDefault(v, d)
+			a, ok := safeFloat64ToFloat32OrZero(v)
 			Expect(ok).To(BeFalse(), "provided value '%v' is recognized as legit", v)
-			Expect(a).To(Equal(d))
+			Expect(a).To(Equal(float32(0)))
 		},
 		Entry("Above Max Float32", math.Nextafter(float64(math.MaxFloat32), math.MaxFloat64)),
 		Entry("Below Min Float32", -(math.Nextafter(float64(math.MaxFloat32), math.MaxFloat64))),

--- a/cmd/main_ginkgo_test.go
+++ b/cmd/main_ginkgo_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"math"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("safeFloat64ToFloat32OrDefault", func() {
+	DescribeTable("converts valid float32 values",
+		func(v float64, e float32) {
+			a, ok := safeFloat64ToFloat32OrDefault(v, 0)
+			Expect(ok).To(BeTrue())
+			Expect(a).To(Equal(e))
+		},
+		Entry("Zero", float64(0), float32(0)),
+		Entry("Smallest Positive Non-Zero",
+			float64(math.SmallestNonzeroFloat32), float32(math.SmallestNonzeroFloat32)),
+		Entry("Smallest Negative Non-Zero",
+			float64(-math.SmallestNonzeroFloat32), float32(-math.SmallestNonzeroFloat32)),
+		Entry("Max float32", float64(math.MaxFloat32), float32(math.MaxFloat32)),
+		Entry("Mix float32", float64(-math.MaxFloat32), float32(-math.MaxFloat32)),
+	)
+
+	DescribeTable("returns default value if provided value is not a valid float32",
+		func(v float64) {
+			d := float32(0)
+
+			a, ok := safeFloat64ToFloat32OrDefault(v, d)
+			Expect(ok).To(BeFalse(), "provided value '%v' is recognized as legit", v)
+			Expect(a).To(Equal(d))
+		},
+		Entry("Above Max Float32", math.Nextafter(float64(math.MaxFloat32), math.MaxFloat64)),
+		Entry("Below Min Float32", -(math.Nextafter(float64(math.MaxFloat32), math.MaxFloat64))),
+		Entry("Max Float64", float64(math.MaxFloat64)),
+		Entry("Min Float64", float64(-math.MaxFloat64)),
+	)
+})

--- a/cmd/main_ginkgo_test.go
+++ b/cmd/main_ginkgo_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("safeFloat64ToFloat32OrDefault", func() {
+var _ = Describe("safeFloat64ToFloat32OrZero", func() {
 	DescribeTable("converts valid float32 values",
 		func(v float64, e float32) {
 			a, ok := safeFloat64ToFloat32OrZero(v)

--- a/cmd/main_ginkgo_test.go
+++ b/cmd/main_ginkgo_test.go
@@ -33,5 +33,8 @@ var _ = Describe("safeFloat64ToFloat32OrDefault", func() {
 		Entry("Below Min Float32", -(math.Nextafter(float64(math.MaxFloat32), math.MaxFloat64))),
 		Entry("Max Float64", float64(math.MaxFloat64)),
 		Entry("Min Float64", float64(-math.MaxFloat64)),
+		Entry("NaN", math.NaN()),
+		Entry("Inf", math.Inf(+1)),
+		Entry("-Inf", math.Inf(-1)),
 	)
 })


### PR DESCRIPTION
We want to be able to configure controller-runtime Client's QPS and Burst by changing the deployment manifest only.

This change will make tekton-kueue get these values from the command flags. In their absence, controller-runtime default values will be used.

Signed-off-by: Francesco Ilario <filario@redhat.com>
