### PR TITLE
fix: Align Renovate/MintMaker configuration with deptriage

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,6 @@
     "github>konflux-ci/mintmaker//config/renovate/renovate.json"
   ],
   "schedule": ["before 7am on Monday"],
-  "minimumReleaseAge": "3 days",
   "enabledManagers": [
     "tekton",
     "dockerfile",
@@ -24,12 +23,14 @@
   },
   "packageRules": [
     {
-      "description": "Group and auto-merge go module patch bumps together",
-      "groupName": "go-modules patch",
+      "description": "Individual PRs for go module patch bumps (auto-approved after CI passes)",
       "matchManagers": ["gomod"],
-      "matchUpdateTypes": ["patch", "digest"],
-      "automerge": true,
-      "addLabels": ["approved", "lgtm", "auto-merged"]
+      "matchUpdateTypes": ["patch"]
+    },
+    {
+      "description": "Individual PRs for go module digest bumps (pseudo-versions have no semver guarantees, treated as minor)",
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["digest"]
     },
     {
       "description": "Individual PRs for go module minor bumps",
@@ -50,21 +51,6 @@
       "matchUpdateTypes": ["minor", "major", "digest"]
     },
     {
-      "description": "Label patch version bumps",
-      "matchUpdateTypes": ["patch", "digest"],
-      "addLabels": ["semver/patch"]
-    },
-    {
-      "description": "Label minor version bumps",
-      "matchUpdateTypes": ["minor"],
-      "addLabels": ["semver/minor"]
-    },
-    {
-      "description": "Label major version bumps",
-      "matchUpdateTypes": ["major"],
-      "addLabels": ["semver/major"]
-    },
-    {
       "description": "Label direct dependencies",
       "matchManagers": ["gomod"],
       "matchDepTypes": ["dependencies"],
@@ -79,28 +65,21 @@
     {
       "description": "Prioritize Konflux tekton task reference updates",
       "matchManagers": ["tekton"],
-      "prPriority": 10,
-      "automerge": true,
-      "addLabels": ["approved", "lgtm", "auto-merged"]
+      "prPriority": 10
     },
     {
-      "description": "Auto-merge dockerfile updates (except Go toolchain)",
+      "description": "Dockerfile updates (except Go toolchain, auto-approved after CI passes)",
       "matchManagers": ["dockerfile"],
-      "excludePackagePatterns": ["go-toolset"],
-      "automerge": true,
-      "addLabels": ["approved", "lgtm", "auto-merged"]
+      "excludePackagePatterns": ["go-toolset"]
     },
     {
-      "description": "Go toolchain updates require manual review",
+      "description": "Go toolchain updates — deptriage defers approval until CI passes",
       "matchManagers": ["dockerfile"],
-      "matchPackagePatterns": ["go-toolset"],
-      "automerge": false
+      "matchPackagePatterns": ["go-toolset"]
     },
     {
-      "description": "Auto-merge rpm-lockfile updates",
-      "matchManagers": ["rpm-lockfile"],
-      "automerge": true,
-      "addLabels": ["approved", "lgtm", "auto-merged"]
+      "description": "RPM lockfile updates (auto-approved after CI passes)",
+      "matchManagers": ["rpm-lockfile"]
     },
     {
       "description": "Block kueue upgrades beyond 0.16.x — kueue v0.17+ drops v1beta1 API support entirely",

--- a/docs/dependency-policy.md
+++ b/docs/dependency-policy.md
@@ -15,8 +15,8 @@ Dependencies are classified using Renovate's native `matchDepTypes`:
 
 Every dependency PR is labeled with the semver bump type:
 
-- `semver/patch` — Patch or digest updates (e.g., 1.2.3 → 1.2.4). Bug fixes only, no new features or breaking changes per semver contract.
-- `semver/minor` — Minor updates (e.g., 1.2.0 → 1.3.0). New features, backwards-compatible.
+- `semver/patch` — Patch updates (e.g., 1.2.3 → 1.2.4). Bug fixes only, no new features or breaking changes per semver contract. Non-gomod digest updates (e.g., container images) are also labeled as patch.
+- `semver/minor` — Minor updates (e.g., 1.2.0 → 1.3.0). New features, backwards-compatible. **Gomod digest/pseudo-version bumps** (e.g., `v0.0.0-20250910...` → `v0.0.0-20260330...`) are also labeled as minor because pseudo-versions have no semver guarantees and may contain breaking changes.
 - `semver/major` — Major updates (e.g., 1.0.0 → 2.0.0). May contain breaking changes.
 
 ### Semver Label Application
@@ -27,12 +27,13 @@ Semver labels are applied by the [deptriage](https://github.com/konflux-ci/deptr
 
 | Update Type | Direct | Transitive | Action |
 |-------------|--------|------------|--------|
-| Patch/digest | Auto-merge | Auto-merge | Merged automatically when CI passes |
+| Patch | Auto-merge | Auto-merge | Merged automatically when CI passes |
+| Gomod digest | Manual review | Manual review | Labeled `semver/minor` — pseudo-versions have no semver guarantees |
 | Minor | Manual review | Manual review | Requires human approval |
 | Major | Manual review | Manual review | Requires human approval |
 | Konflux references (Tekton tasks) | N/A | N/A | Auto-merge when CI passes |
 | Dockerfile updates | N/A | N/A | Auto-merge when CI passes |
-| Go toolchain (go-toolset) | N/A | N/A | **Manual review required** |
+| Go toolchain (go-toolset) | N/A | N/A | Auto-merge when CI passes (deferred approval) |
 | RPM lockfile updates | N/A | N/A | Auto-merge when CI passes |
 
 Auto-merge is handled by the [deptriage](https://github.com/konflux-ci/deptriage) action via two workflows:
@@ -42,20 +43,22 @@ Auto-merge is handled by the [deptriage](https://github.com/konflux-ci/deptriage
 
 ### Rationale
 
-- **Patch bumps** are low-risk by semver convention (bug fixes only). Combined with CI validation, auto-merging reduces review burden without meaningful risk.
+- **Patch bumps** are low-risk by semver convention (bug fixes only). Combined with CI validation, auto-approving reduces review burden without meaningful risk.
+- **Gomod digest/pseudo-version bumps** use `v0.0.0-timestamp-hash` versions with no semver guarantees. Breaking API changes have been observed in k8s.io pseudo-version bumps, so these require manual review with AI impact analysis.
 - **Minor/major bumps** may introduce new behavior or breaking changes and benefit from human review.
 - **Konflux reference updates** are digest-only updates to build pipeline task references — they are validated by the Tekton pipeline CI.
-- **Go toolchain updates** (`go-toolset` image) are flagged with risk hints. Approval is deferred until CI passes, as these updates have historically caused CI failures.
+- **Go toolchain updates** (`go-toolset` image) are flagged with risk hints and assessed as MEDIUM risk. Approval is deferred until the Konflux CI pipeline passes, proving the build is safe with the new toolchain.
 - **AI risk level** is informational — MEDIUM risk does NOT block merge. Only HIGH risk prevents auto-merge and requires human review.
 
 ## PR Grouping
 
-Go module updates are grouped to reduce PR volume:
+Go module updates are individual PRs (no grouping) to allow independent merging and failure isolation. One failing update does not block other safe updates.
 
-- `go-modules patch` — All patch/digest bumps in one PR
-- `go-modules minor` — All minor bumps in one PR
-- Major bumps — Individual PRs per package (ungrouped)
-- `go-modules k8s` — Kubernetes-related packages (`k8s.io/*`, `sigs.k8s.io/controller-runtime`) grouped together for minor/major/digest updates
+- Patch bumps — Individual PRs per package
+- Digest bumps — Individual PRs per package
+- Minor bumps — Individual PRs per package
+- Major bumps — Individual PRs per package
+- `go-modules k8s` — Exception: Kubernetes-related packages (`k8s.io/*`, `sigs.k8s.io/controller-runtime`) are grouped together for minor/major/digest updates because they are tightly coupled and must be upgraded together
 
 ## Import Usage and Impact Analysis
 
@@ -63,13 +66,13 @@ For dependency PRs, the deptriage action gathers code-level usage context (via `
 
 ## Override Procedure
 
-To exclude a specific package from auto-merge, the deptriage action's risk detection will flag packages with known risk patterns. For additional overrides, add a `packageRules` entry in `renovate.json` to prevent Renovate from grouping the package with auto-mergeable updates:
+To exclude a specific package from auto-merge, the deptriage action's risk detection will flag packages with known risk patterns. For additional overrides, add a `packageRules` entry in `renovate.json` with a label that deptriage recognizes as blocking (e.g., `risk/high`):
 
 ```json
 {
   "description": "Require manual review for package-name",
   "matchPackageNames": ["github.com/example/package-name"],
-  "groupName": null
+  "addLabels": ["risk/high"]
 }
 ```
 


### PR DESCRIPTION
The previous `Renovate` config had three issues observed in practice that are preventing `deptriage` to work as expected:

1. The `approved` and `lgtm` labels were applied at PR creation time, before any CI checks ran. This caused PRs with failing tests to be labeled as approved, misleading the merge bot.

2. Patch-version Go module bumps were grouped into a single PR. When one dependency in the group broke tests, all other safe upgrades were blocked from merging — defeating the goal of auto-merging low-risk updates.

3. The `minimumReleaseAge` of 3 days prevented green PRs from merging promptly, adding unnecessary delay with no clear benefit given that CI already validates the upgrades.

Changes:
- Remove `minimumReleaseAge` so green PRs can merge without delay
- Remove `groupName` for gomod patch bumps so each gets its own PR
- Remove `automerge` and approved/lgtm/auto-merged labels from all Renovate package rules (gomod patch, tekton, dockerfile, rpm-lockfile)
- Removes redundant `semver/patch`, `semver/minor`, `semver/major` label rules since `deptriage` now applies these during the  classify phase.
- Removes unnecessary `automerge: false` on go-toolset since no automerge is set.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

Contributes to: KFLUXINFRA-3008