### PR TITLE
Add AGENTS.md and CI lint workflow

### DIFF
--- a/.github/workflows/agents-md-lint.yaml
+++ b/.github/workflows/agents-md-lint.yaml
@@ -1,0 +1,33 @@
+name: Lint AGENTS.md
+
+on:
+  pull_request:
+    paths:
+      - AGENTS.md
+  push:
+    branches: [main]
+    paths:
+      - AGENTS.md
+
+permissions:
+  contents: read
+
+jobs:
+  agents-md-lint:
+    name: Check AGENTS.md line limit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Validate AGENTS.md
+        run: |
+          if [ ! -f AGENTS.md ]; then
+            echo "ERROR: AGENTS.md not found"
+            exit 1
+          fi
+          lines=$(wc -l < AGENTS.md)
+          echo "AGENTS.md has $lines lines (limit: 300)"
+          if [ "$lines" -gt 300 ]; then
+            echo "ERROR: AGENTS.md exceeds 300-line limit"
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,63 @@
+# tekton-kueue
+
+Go controller (kubebuilder) integrating Tekton PipelineRuns with Kueue for
+resource-aware scheduling via admission webhook and CEL-based mutations.
+
+## Quick Commands
+
+| Action         | Command                                               |
+|----------------|-------------------------------------------------------|
+| Build          | `make build`                                          |
+| Unit tests     | `make test`                                           |
+| E2E tests      | `make test-e2e` (requires Kind cluster)               |
+| Lint           | `make lint`                                           |
+| Generate CRDs  | `make manifests`                                      |
+| Generate code  | `make generate`                                       |
+| Deploy         | `make deploy IMG=<tag>`                               |
+| Mutate CLI     | `tekton-kueue mutate --pipelinerun-file <f> --config-dir <d>` |
+
+## Project Layout
+
+- `cmd/` — entrypoint with subcommands: `controller`, `webhook`, `mutate`.
+- `internal/controller/` — PipelineRun → Workload reconciler.
+- `internal/webhook/` — admission webhook with CEL mutation engine.
+- `internal/cel/` — CEL functions: `annotation()`, `label()`, `priority()`,
+  `resource()` plus convenience vars (`plrNamespace`, `pacEventType`).
+- `pkg/` — `mutate` (CLI logic), `common` (utilities), `config` (ConfigMap).
+- `config/` — Kustomize manifests; `test/e2e/` — e2e tests.
+
+## Key Conventions
+
+- Kubebuilder scaffolded — run `make manifests` and `make generate` after
+  modifying API types or RBAC markers.
+- CEL `resource()` values with same key are summed; rejects negatives.
+- MultiKueue mode via `multiKueueOverride: true` in ConfigMap.
+- `mutate` CLI previews webhook behavior offline — use before production.
+- Coverage instrumentation toggled via `ENABLE_COVERAGE=true`.
+- All changes via PR; review required.
+
+## Testing
+
+- **Unit tests**: Ginkgo with envtest. Run with `make test`. Covers
+  controller, webhook, and CEL engine.
+- **E2E tests**: Kind cluster with Kueue and Tekton. `make test-e2e`
+  handles full lifecycle. Coverage via coverport-cli, uploaded to Codecov.
+- **CLI testing**: `tekton-kueue mutate` previews webhook mutations
+  offline — validates CEL expressions without a cluster.
+
+## CI Pipeline (GitHub Actions)
+
+- `test` — unit tests on push/PR, coverage to Codecov.
+- `test-e2e` — Kind cluster with Kueue+Tekton, instrumented image, e2e
+  tests, coverage via coverport-cli.
+- `lint` — golangci-lint on PRs.
+- `dep-triage` — auto-triages Renovate/Konflux bot dependency PRs.
+- `auto-merge` — merges approved dependency PRs when all checks pass.
+
+## Gotchas
+
+- E2E tests use `KIND_EXPERIMENTAL_PROVIDER=podman`.
+- CertManager required for webhook TLS certificates.
+- Kueue must have `pipelineruns.tekton.dev` in external frameworks config.
+- Changing CEL expression syntax may silently change PipelineRun mutations
+  in production — always test with `mutate` CLI first.


### PR DESCRIPTION
Add agent instructions following the infra team AGENTS.md template: project description, quick commands, layout, conventions, testing, CI pipeline, and gotchas. Add GitHub Actions workflow to enforce the 300-line limit on AGENTS.md changes.

Closes: KFLUXINFRA-3737