### PR TITLE
docs(KFLUXINFRA-3756): add single-file verification and CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,14 @@ resource-aware scheduling via admission webhook and CEL-based mutations.
 | Deploy         | `make deploy IMG=<tag>`                               |
 | Mutate CLI     | `tekton-kueue mutate --pipelinerun-file <f> --config-dir <d>` |
 
+### Single-File Verification
+
+- Lint package: `golangci-lint run ./path/to/package/`
+- Vet package: `go vet ./path/to/package/`
+- Test package: `go test ./path/to/package/`
+- Test with race: `go test -race ./path/to/package/`
+- Format file: `gofmt -w path/to/file.go`
+
 ## Project Layout
 
 - `cmd/` — entrypoint with subcommands: `controller`, `webhook`, `mutate`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
Add single-file verification commands to AGENTS.md for lint, vet, test, format, and YAML lint. Add CLAUDE.md pointer to AGENTS.md.

Addresses AgentReady Tier 1 finding: single_file_verification (0 -> pass).