### PR TITLE
KFLUXINFRA-3775: add AI skills for tekton-kueue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,3 +78,9 @@ When making common changes, use these as reference implementations:
 - Kueue must have `pipelineruns.tekton.dev` in external frameworks config.
 - Changing CEL expression syntax may silently change PipelineRun mutations
   in production — always test with `mutate` CLI first.
+
+## Skills
+
+- Before opening a PR, writing a PR description, or interpreting CI results, read `skills/pr-workflow.md`
+- When a CI check fails on a PR, read `skills/ci-troubleshooting.md`
+- When working interactively on new features or significant changes, read `skills/brainstorming-workflow.md` before making changes

--- a/skills/brainstorming-workflow.md
+++ b/skills/brainstorming-workflow.md
@@ -1,0 +1,68 @@
+---
+name: brainstorming-workflow
+description: >
+  Use when in an interactive session and the user requests a new feature, significant
+  change, refactor, or architectural decision in tekton-kueue. Provides a structured
+  process choice before any changes are made. Skip when dispatched with a complete task.
+---
+
+# Brainstorming Workflow
+
+Discipline for interactive sessions involving new features, refactors, performance optimizations, API changes, or other significant changes.
+
+## Context Detection
+
+- **Interactive session** (human in CLI/IDE): follow this workflow.
+- **Dispatched with a complete task** (sub-agent, automation, explicit spec): skip entirely and execute.
+
+## First Message
+
+Before making any changes, ask exactly ONE question:
+
+> I can approach this a few ways:
+>
+> A) Jump straight to making changes
+> B) Discuss approaches first, then make changes
+> C) Full design process — explore approaches, write up a plan, then execute
+>
+> Which works for you?
+
+**Always ask this question first**, even when the request sounds urgent. It's a quick check that keeps things on track.
+
+**After asking**, if the human replies with "just do it", gives a direct instruction, or otherwise signals urgency, treat as **A**. But ask first — don't skip the question based on tone or urgency cues in the initial request.
+
+## Path A — Jump to Changes
+
+Proceed directly. All existing conventions still apply (pr-workflow, testing requirements). No additional ceremony.
+
+## Path B — Discuss Approaches
+
+1. **Understand the problem**: what is being changed, why, and any constraints.
+2. **Propose 2-3 approaches** with trade-offs (complexity, test coverage impact, performance implications, API compatibility).
+3. **Lead with a recommendation** and explain why.
+4. Let the human choose, then execute.
+
+tekton-kueue examples where this helps:
+- Choosing between extending an existing CEL function vs adding a new one
+- Deciding how to restructure webhook mutation logic for a new use case
+- Planning how to add a new controller reconciler or modify the existing one
+- Evaluating whether a change needs new e2e test scenarios or unit tests are sufficient
+- Designing changes to the `mutate` CLI vs webhook behavior
+- Adding or modifying Kustomize manifests in `config/`
+
+Ask one question at a time. Prefer multiple choice over open-ended questions.
+
+## Path C — Full Design Process
+
+Everything in Path B, plus:
+
+1. **Write up the plan** — what changes in which files/packages, test strategy, API impact.
+2. **Break into ordered steps** with dependencies (e.g., add types first, then controller logic, then tests).
+3. Get human approval before executing.
+
+## Key Principles
+
+- **One question at a time.** Never pile up multiple questions in one message.
+- **Prefer multiple choice.** Easier for the human to decide quickly.
+- **Human decides the process, not the agent.** Respect the chosen path.
+- **"Just do it" means just do it.** Don't add process the human didn't ask for.

--- a/skills/ci-troubleshooting.md
+++ b/skills/ci-troubleshooting.md
@@ -1,0 +1,135 @@
+---
+name: ci-troubleshooting
+description: >
+  Use when a CI check fails on a PR in tekton-kueue and you need to
+  understand what failed, how to read the logs, and how to fix it.
+---
+
+# CI Troubleshooting
+
+## Overview
+
+How to investigate and fix CI failures on tekton-kueue PRs.
+
+## When to Use
+
+- A CI check failed on your PR
+- You need to understand what a CI comment or status means
+- You want to re-trigger a flaky test
+
+## Prerequisites
+
+Verify `gh` CLI is installed and authenticated:
+
+```bash
+gh auth status
+```
+
+All CI investigation commands below depend on it.
+
+## Reading CI Logs
+
+### GitHub Actions checks
+
+```bash
+gh pr checks <PR-number> --repo konflux-ci/tekton-kueue
+```
+
+To investigate a failed check:
+
+```bash
+gh run view <run-id> --repo konflux-ci/tekton-kueue
+gh run view <run-id> --repo konflux-ci/tekton-kueue --log-failed
+```
+
+### Tekton / Konflux pipeline checks
+
+Tekton pipeline runs (pull-request and push pipelines defined in `.tekton/`) execute inside the Konflux platform. These are best investigated manually through the Konflux UI.
+
+If a Tekton pipeline check fails, you can comment `/retest` on the PR to re-trigger, but if the failure persists, escalate to a human who can inspect the logs in the Konflux UI.
+
+## Common Failures
+
+### test (unit tests)
+
+Ginkgo tests with envtest, run via `go test`. The GitHub Actions log shows which specs failed and the failure messages. To reproduce locally:
+
+```bash
+make test
+```
+
+If a specific test is failing, run it in isolation:
+
+```bash
+go test ./path/to/package/ -run "TestName"
+```
+
+For Ginkgo specs, you can also focus by description:
+
+```bash
+go test ./path/to/package/ --ginkgo.focus="description of failing spec"
+```
+
+### test-e2e
+
+End-to-end tests running on a Kind cluster with Kueue and Tekton installed. These require Kind, Kueue, Tekton, and CertManager. Common causes of failure:
+- Kind cluster not running or misconfigured
+- Kueue or Tekton not installed in the cluster
+- CertManager not deployed (required for webhook TLS)
+- Actual test failure (check the Ginkgo output for the failing spec)
+
+To reproduce locally:
+
+```bash
+# Set up a Kind cluster with dependencies (if not already running)
+kind create cluster
+make cert-manager
+make tekton
+make kueue
+
+# Build and load the image, then run e2e tests
+make load-image
+make deploy
+make test-e2e
+```
+
+Note: E2E tests use `KIND_EXPERIMENTAL_PROVIDER=podman` in CI.
+
+### lint
+
+golangci-lint violations. The log shows the exact file, line, and linter rule. Fix the reported issues or run locally:
+
+```bash
+make lint
+```
+
+### go mod tidy
+
+`go.mod` or `go.sum` are not tidy. Fix:
+
+```bash
+go mod tidy
+```
+
+Then commit the changes.
+
+### Tekton pipeline failures
+
+The `.tekton/` pipelines run security scans and multi-arch container builds. These run inside Konflux and their logs are not accessible from the CLI. If they fail:
+
+1. Comment `/retest` on the PR to re-trigger.
+2. If the failure persists, these are best investigated manually through the Konflux UI by a human.
+
+## Re-running Failed Jobs
+
+Find the run ID from the PR checks output:
+
+```bash
+gh pr checks <PR-number> --repo konflux-ci/tekton-kueue
+```
+
+The run ID is part of the check's detail URL. Then rerun only the failed jobs:
+
+```bash
+gh run rerun <run-id> --repo konflux-ci/tekton-kueue --failed
+```

--- a/skills/pr-workflow.md
+++ b/skills/pr-workflow.md
@@ -1,0 +1,120 @@
+---
+name: pr-workflow
+description: >
+  Use when opening, monitoring, or iterating on a pull request in tekton-kueue,
+  including PR body template, CI interpretation, and commit conventions.
+---
+
+# PR Workflow
+
+Full lifecycle reference for pull requests in the tekton-kueue repository.
+
+## Overview
+
+tekton-kueue is a Go controller (kubebuilder) integrating Tekton PipelineRuns with Kueue for resource-aware scheduling via admission webhook and CEL-based mutations. PRs target `main` on the upstream repository.
+
+## When to Use
+
+- About to open a PR or write a PR description
+- Iterating on a PR based on review feedback
+- Preparing commits for a change
+
+## Branch Setup
+
+If a dedicated branch already exists for this work, use it. Otherwise, create a branch from the latest main of `konflux-ci/tekton-kueue`.
+
+First, find which remote points to `konflux-ci/tekton-kueue`:
+
+```bash
+git remote -v | grep konflux-ci/tekton-kueue
+```
+
+Then fetch and branch from it:
+
+```bash
+git fetch <remote>
+git checkout -b <branch-name> <remote>/main --no-track
+```
+
+Common setups: fork-based workflows typically name it `upstream`, while direct clones use `origin`.
+
+Never branch from an old or diverged main.
+
+## PR Body Template
+
+The repo has a PR template at `.github/PULL_REQUEST_TEMPLATE.md`. Follow it:
+
+```markdown
+## What
+
+<!-- Brief description of the change -->
+
+## Why
+
+<!-- Motivation or link to Jira issue, e.g. KFLUXINFRA-1234 -->
+
+## Verification
+
+- [ ] `make lint` passes
+- [ ] `make test` passes
+- [ ] Tested with `tekton-kueue mutate` CLI (if CEL/webhook changes)
+- [ ] `make manifests` and `make generate` run cleanly (if API/RBAC changes)
+```
+
+**Rules:**
+- **What** — Concise change list. Don't explain why here.
+- **Why** — Motivation and/or Jira link. Keep it brief.
+- **Verification** — Check off each item that applies. Add additional items if the change warrants it (e.g., e2e tests).
+
+## PR Title
+
+Prefix with the Jira key, keep it short:
+
+```
+KFLUXINFRA-1234: short description of the change
+```
+
+## Commit Conventions
+
+Prefix every commit with the Jira key:
+
+```
+KFLUXINFRA-1234: short description of the change
+```
+
+Always use `-s` flag (DCO sign-off).
+
+Trailers (at end of commit message body):
+- Interactive sessions (human + agent): `Assisted-by: Agent Name`
+- Agentic workflow (autonomous): `Authored-by: Agent Name`
+
+## Key CI Checks
+
+| Check | What It Does |
+|-------|--------------|
+| **test** | Go tests with envtest, coverage uploaded to Codecov. |
+| **test-e2e** | Kind cluster with Kueue+Tekton, instrumented image, e2e tests, coverage via coverport-cli. |
+| **lint** | golangci-lint on PRs. |
+| **auto-merge** | Merges approved dependency PRs when all checks pass. |
+| **Tekton pipelines** | Multi-arch container builds and security scans. Run inside Konflux — best investigated manually through the Konflux UI. |
+
+**CI caveats:**
+- E2E tests can be flaky due to Kind cluster setup — if logs show no relevant errors, rerun with `gh run rerun <run-id> --failed`.
+- Tekton pipeline failures are best investigated manually through the Konflux UI. Use `/retest` to re-trigger, but don't try to diagnose these yourself.
+- After modifying API types or RBAC markers, run `make manifests` and `make generate` before committing.
+
+## Interactive Sessions
+
+In interactive sessions (human + agent), always confirm with the human before pushing and opening the PR. Show them the commit message, PR title, and PR body for approval first. Never push or create a PR without explicit approval.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Not running tests before pushing | Run `make test` and `make lint` locally, mention results in Testing |
+| Putting explanation in Testing instead of evidence | Testing = which tests ran and passed. Why = explanation. |
+| Branching from a stale main | Always fetch and reset from origin before branching |
+| Missing Jira key in commit message | Prefix every commit with `KFLUXINFRA-1234` |
+| Forgetting `make manifests` / `make generate` | Run after any API type or RBAC marker changes |
+| Not testing CEL changes with `mutate` CLI | Use `tekton-kueue mutate` to preview webhook mutations offline before pushing |
+| Running tests with `go test ./...` | Use `make test` — it handles envtest setup and code generation |


### PR DESCRIPTION
## What

Add `skills/` directory with three AI skills and link them from AGENTS.md.

- `skills/brainstorming-workflow.md` — structured process choice for interactive sessions
- `skills/ci-troubleshooting.md` — how to investigate and fix CI failures
- `skills/pr-workflow.md` — PR lifecycle reference (template, commits, CI checks)

[KFLUXINFRA-3775](https://redhat.atlassian.net/browse/KFLUXINFRA-3775)

## Why

Enable AI agents to follow repo-specific workflows for PRs, CI troubleshooting, and brainstorming.

## Verification

- [x] `make lint` passes
- [x] `make test` passes
- [x] Skills tested with subagents (retrieval and application scenarios for all three skills — verified agents can find and correctly apply information from each skill)

[KFLUXINFRA-3775]: https://redhat.atlassian.net/browse/KFLUXINFRA-3775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ