### PR TITLE
fix(cve): upgrade Go stdlib go 1.25.3 → 1.25.11 (release-v0.3.x)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/konflux-ci/tekton-kueue
 
-go 1.25.3
+go 1.25.11
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
## CVE Details

Multiple Go standard library vulnerabilities fixed by upgrading from Go 1.25.3 → 1.25.11.

| Vuln ID | CVE | Package | Fixed in |
|---------|-----|---------|----------|
| GO-2026-5039 | CVE-2026-42507 | net/textproto | go1.25.11 |
| GO-2026-5038 | CVE-2026-42504 | mime | go1.25.11 |
| GO-2026-5037 | CVE-2026-27145 | crypto/x509 | go1.25.11 |
| GO-2026-4986 | CVE-2026-39820 | net/mail | go1.25.10 |
| GO-2026-4982 | CVE-2026-39823 | html/template | go1.25.10 |
| GO-2026-4980 | CVE-2026-39826 | html/template | go1.25.10 |
| GO-2026-4977 | CVE-2026-42499 | net/mail | go1.25.10 |
| GO-2026-4971 | CVE-2026-39836 | net | go1.25.10 |
| GO-2026-4947 | CVE-2026-32280 | crypto/x509 | go1.25.9 |
| GO-2026-4946 | CVE-2026-32281 | crypto/x509 | go1.25.9 |
| GO-2026-4918 | CVE-2026-33814 | net/http | go1.25.10 |
| GO-2026-4870 | CVE-2026-32283 | crypto/tls | go1.25.9 |
| GO-2026-4865 | CVE-2026-32289 | html/template | go1.25.9 |
| GO-2026-4603 | CVE-2026-27142 | html/template | go1.25.8 |
| GO-2026-4602 | CVE-2026-27139 | os | go1.25.8 |
| GO-2026-4601 | CVE-2026-25679 | net/url | go1.25.8 |
| GO-2026-4341 | — | net/url | go1.25.6 |
| GO-2026-4340 | — | crypto/tls | go1.25.6 |
| GO-2026-4337 | — | crypto/tls | go1.25.7 |
| GO-2025-4175 | — | crypto/x509 | go1.25.5 |
| GO-2025-4155 | — | crypto/x509 | go1.25.5 |

## Fix Summary

Changed `go` directive in `go.mod` from `1.25.3` to `1.25.11`. This is the minimal change to address all reachable stdlib vulnerabilities on this branch. `go mod tidy && go mod verify` both pass. Note: `golang.org/x/net` is already at v0.56.0 on this branch (CVE-2026-39821 already fixed).

## Test Results

- ✅ `go build ./...` — passes
- ✅ `go mod verify` — all modules verified
- ⚠️ `go test ./internal/controller` — BeforeSuite failure requiring envtest/Kubernetes API server (pre-existing, not caused by this change)
- ✅ `go test ./internal/webhook/...` — passes
- ✅ `go test ./pkg/mutate` — passes

## Breaking Changes

None. The `go` directive bump is backwards-compatible for the module consumers.

## Risk Assessment

**Low** — Single line change in go.mod bumping the stdlib toolchain version. No module dependency changes. govulncheck confirms all 21 stdlib vulnerabilities are resolved after this change.

## Verification Steps

- [ ] Run `govulncheck ./...` — should show only tektoncd/pipeline vulnerabilities (no stdlib or x/net)
- [ ] Verify `go build ./...` succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)