### PR TITLE
Add param validation proposal for webhook CEL type safety

### DIFF
--- a/openspec/changes/add-param-validation/.openspec.yaml
+++ b/openspec/changes/add-param-validation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-30

--- a/openspec/changes/add-param-validation/design.md
+++ b/openspec/changes/add-param-validation/design.md
@@ -1,0 +1,58 @@
+## Context
+
+The tekton-kueue webhook intercepts PipelineRun creation and applies CEL-based mutations (resource requests, priorities, labels). CEL expressions are configured in a ConfigMap deployed from infra-deployments. The expressions call `.map()` and `.filter()` on `build-platforms` param values, assuming they are arrays. When a PipelineRun submits `build-platforms` as a string, the CEL runtime crashes with HTTP 500 (`EvaluationError`). The webhook uses `failurePolicy: Fail`, so this blocks PipelineRun creation entirely.
+
+The tekton-kueue CEL environment includes `cel.StdLib()`, which provides the `type()` function. After JSON marshaling (how PipelineRun params are passed to CEL), string params become CEL `string` and array params become CEL `list(dyn)`. This means `type(x) == list` reliably distinguishes the two cases.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Prevent HTTP 500 by adding `type()` guards to CEL expressions that call `.map()`/`.filter()` on param values
+- Provide operator visibility via a validation-error annotation when a param has the wrong type
+- Deny malformed PipelineRuns during the no-skip-kueue rollout via ValidatingAdmissionPolicy
+- Keep tekton-kueue code unchanged — all fixes are config-level in infra-deployments
+
+**Non-Goals:**
+- Modifying tekton-kueue Go code (controller, webhook, CEL engine)
+- Validating param types beyond `build-platforms` (can be extended later with the same pattern)
+- Providing user-facing error propagation through PaC (PaC doesn't propagate admission errors)
+
+## Decisions
+
+### Config-only fix using CEL `type()` guards
+The CEL expressions themselves are modified to check `type(value) == list` before calling `.map()`. When the type is wrong, the expression returns `[]` (no resource request). This is preferred over a Go-level validation layer because it requires zero code changes to tekton-kueue, keeping the project simple. The existing `type()` function from `cel.StdLib()` already supports this.
+
+### Validation-error annotation for observability
+A separate CEL expression detects wrong-typed params and adds a `tekton-kueue.konflux-ci.dev/validation-error` annotation. This leaves a debug trail on the PipelineRun object, making it easy to find and diagnose affected runs. The `annotation()` function is already available in the CEL environment.
+
+### ValidatingAdmissionPolicy for denial (temporary)
+During the no-skip-kueue rollout, PipelineRuns with wrong-typed params must be denied — otherwise they'd be admitted with no resource requests, bypassing the queue. A Kubernetes-native `ValidatingAdmissionPolicy` reads the validation-error annotation and denies the request. This is decoupled from the webhook and can be removed independently once the rollout completes.
+
+After the rollout, the annotation-only approach is sufficient: the PipelineRun is admitted (queued correctly for other resources) with an explanatory annotation, which is a better UX than outright rejection since PaC doesn't propagate admission errors to users.
+
+### CEL expression structure
+The type guard is added inline to each expression that accesses `.value.map()` or `.value.filter()`:
+
+```cel
+has(pipelineRun.spec.params) &&
+pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) == list ?
+pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0]
+.value.map(p, resource(...)) : []
+```
+
+The error annotation expression uses the inverse check (`!= list`):
+```cel
+has(pipelineRun.spec.params) &&
+pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) != list ?
+annotation('tekton-kueue.konflux-ci.dev/validation-error',
+  'build-platforms must be an array of platform strings') : []
+```
+
+## Risks / Trade-offs
+
+- **CEL expression complexity** — Adding `type()` guards makes the expressions longer and harder to read. → Acceptable trade-off for zero code changes; the expressions are already complex.
+- **ValidatingAdmissionPolicy lifecycle** — Must be removed after no-skip-kueue rollout or it will continue denying requests unnecessarily. → Document the removal step; the policy is isolated in its own kustomize resource.
+- **Pattern not generalized** — Each new type-sensitive param needs manual guards added to the CEL expressions. → Acceptable for now; `build-platforms` is the only known case. If more arise, a Go-level validation layer can be reconsidered.
+- **`type()` comparison syntax** — Need to verify that `type(x) == list` compiles and evaluates correctly in the tekton-kueue CEL environment (confirmed: `cel.StdLib()` provides `type()`, and JSON-unmarshaled arrays become CEL `list(dyn)` which matches the `list` type).

--- a/openspec/changes/add-param-validation/proposal.md
+++ b/openspec/changes/add-param-validation/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The webhook's CEL expressions assume certain PipelineRun parameters have specific types (e.g., `build-platforms` is an array). When a PipelineRun submits a param with the wrong type, the CEL `.map()` call crashes at runtime, returning HTTP 500 (InternalServerError). This was observed in production on kflux-prd-rh02 (2026-06-09). Additionally, during the no-skip-kueue rollout, a malformed PipelineRun that passes without resource requests would effectively skip the queue.
+
+## What Changes
+
+All changes are in infra-deployments — no tekton-kueue code changes required.
+
+- Add `type()` guards to the build-platforms CEL expressions so they return `[]` instead of crashing when the value is a string. This eliminates the HTTP 500.
+- Add a new CEL expression that detects wrong-typed `build-platforms` and sets a `tekton-kueue.konflux-ci.dev/validation-error` annotation with an error message. This provides operator visibility.
+- Add a ValidatingAdmissionPolicy that denies PipelineRuns carrying the validation-error annotation. This is needed during the no-skip-kueue rollout to prevent queue bypass; it can be removed once the rollout completes.
+- Add test cases to `hack/test-tekton-kueue-config.py` for string-typed `build-platforms`.
+
+## Capabilities
+
+### New Capabilities
+
+- `cel-type-guard`: CEL `type()` guards on build-platforms expressions and a validation-error annotation expression, all in infra-deployments config.yaml.
+- `validating-admission-policy`: A Kubernetes ValidatingAdmissionPolicy that denies PipelineRuns with the validation-error annotation (temporary, for no-skip-kueue rollout).
+
+### Modified Capabilities
+
+## Impact
+
+- `components/kueue/production/base/tekton-kueue/config.yaml` — modified CEL expressions + new annotation expression
+- `components/kueue/production/base/` — new ValidatingAdmissionPolicy resource
+- `hack/test-tekton-kueue-config.py` — new test case for string-typed build-platforms
+- No changes to tekton-kueue Go code

--- a/openspec/changes/add-param-validation/specs/param-validation/spec.md
+++ b/openspec/changes/add-param-validation/specs/param-validation/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: CEL type guards prevent crashes on wrong param types
+The build-platforms CEL expressions in config.yaml SHALL include a `type()` guard that checks `type(value) == list` before calling `.map()` or `.filter()` on the param value. When the value is not a list, the expression SHALL return `[]` instead of crashing.
+
+#### Scenario: String build-platforms does not crash
+- **WHEN** a PipelineRun has param `build-platforms` with type `string`
+- **THEN** the resource request expression SHALL return `[]` (no resource requests)
+- **AND** the webhook SHALL NOT return HTTP 500
+
+#### Scenario: Array build-platforms works as before
+- **WHEN** a PipelineRun has param `build-platforms` with type `array` containing `["linux/amd64", "linux/arm64"]`
+- **THEN** the resource request expression SHALL return resource requests for each platform
+- **AND** the AWS IP expression SHALL return AWS IP requests for eligible platforms
+
+#### Scenario: Absent build-platforms works as before
+- **WHEN** a PipelineRun does not have a `build-platforms` param
+- **THEN** the existing `exists()` guard SHALL cause the expression to return `[]`
+
+### Requirement: Validation-error annotation on wrong param type
+A CEL expression SHALL detect when `build-platforms` is present but not a list, and set the annotation `tekton-kueue.konflux-ci.dev/validation-error` with an error message describing the type mismatch.
+
+#### Scenario: String build-platforms gets error annotation
+- **WHEN** a PipelineRun has param `build-platforms` with type `string`
+- **THEN** the PipelineRun SHALL have annotation `tekton-kueue.konflux-ci.dev/validation-error` set
+- **AND** the annotation value SHALL describe that build-platforms must be an array
+
+#### Scenario: Array build-platforms gets no error annotation
+- **WHEN** a PipelineRun has param `build-platforms` with type `array`
+- **THEN** the PipelineRun SHALL NOT have a `tekton-kueue.konflux-ci.dev/validation-error` annotation
+
+#### Scenario: Absent build-platforms gets no error annotation
+- **WHEN** a PipelineRun does not have a `build-platforms` param
+- **THEN** the PipelineRun SHALL NOT have a `tekton-kueue.konflux-ci.dev/validation-error` annotation
+
+### Requirement: ValidatingAdmissionPolicy denies annotated PipelineRuns
+A Kubernetes ValidatingAdmissionPolicy SHALL deny PipelineRun creation when the `tekton-kueue.konflux-ci.dev/validation-error` annotation is present. This policy is temporary and SHALL be removed after the no-skip-kueue rollout completes.
+
+#### Scenario: PipelineRun with validation-error annotation is denied
+- **WHEN** a PipelineRun has the `tekton-kueue.konflux-ci.dev/validation-error` annotation
+- **THEN** the ValidatingAdmissionPolicy SHALL deny the request
+
+#### Scenario: PipelineRun without validation-error annotation is allowed
+- **WHEN** a PipelineRun does not have the `tekton-kueue.konflux-ci.dev/validation-error` annotation
+- **THEN** the ValidatingAdmissionPolicy SHALL allow the request
+
+### Requirement: Test coverage for string-typed build-platforms
+The test script `hack/test-tekton-kueue-config.py` SHALL include test cases for PipelineRuns with string-typed `build-platforms` params, verifying that the validation-error annotation is set and no resource requests are generated.
+
+#### Scenario: Test validates string build-platforms produces error annotation
+- **WHEN** the test submits a PipelineRun with `build-platforms` as a string param
+- **THEN** the expected results SHALL include the `tekton-kueue.konflux-ci.dev/validation-error` annotation
+- **AND** the expected results SHALL NOT include any `kueue.konflux-ci.dev/requests-*` annotations for platforms

--- a/openspec/changes/add-param-validation/tasks.md
+++ b/openspec/changes/add-param-validation/tasks.md
@@ -1,0 +1,22 @@
+## 1. CEL Type Guards (infra-deployments)
+
+- [ ] 1.1 Add `type()` guard to the build-platforms resource request expression (lines 5-14 of config.yaml): check `type(value) == list` before `.map()`
+- [ ] 1.2 Add `type()` guard to the build-platforms AWS IP expression (lines 17-37 of config.yaml): check `type(value) == list` before `.filter()`
+- [ ] 1.3 Add new CEL expression for validation-error annotation: detect `build-platforms` present but `type(value) != list`, set `tekton-kueue.konflux-ci.dev/validation-error` annotation
+
+## 2. ValidatingAdmissionPolicy (infra-deployments)
+
+- [ ] 2.1 Create ValidatingAdmissionPolicy resource that denies PipelineRuns with `tekton-kueue.konflux-ci.dev/validation-error` annotation
+- [ ] 2.2 Create ValidatingAdmissionPolicyBinding to apply the policy to PipelineRun resources
+- [ ] 2.3 Add both resources to the kustomization.yaml
+
+## 3. Tests (infra-deployments)
+
+- [ ] 3.1 Add PipelineRun test case in `hack/test-tekton-kueue-config.py` with `build-platforms` as a string param
+- [ ] 3.2 Define expected results: validation-error annotation present, no platform resource request annotations
+- [ ] 3.3 Run `python hack/test-tekton-kueue-config.py` — all tests pass including new string-typed build-platforms case
+
+## 4. Verification
+
+- [ ] 4.1 Verify the modified CEL expressions compile by running the test script against the production base config
+- [ ] 4.2 Verify existing array-typed build-platforms tests still pass (no regression)


### PR DESCRIPTION
## What
Adds an OpenSpec change proposal for configurable PipelineRun parameter type validation that runs before CEL evaluation, returning 400 instead of 500 when a param has the wrong type (e.g., string instead of array).

## Why
[KFLUXINFRA-3980](https://redhat.atlassian.net/browse/KFLUXINFRA-3980)

## Verification

- [N/A] `make lint` passes
- [N/A ] `make test` passes
- [N/A] Tested with `tekton-kueue mutate` CLI (if CEL/webhook changes)
- [N/A] `make manifests` and `make generate` run cleanly (if API/RBAC changes)

## Note to reviewers:
The idea is not to merge this change but to serve to discuss and agree in the implementation

[KFLUXINFRA-3980]: https://redhat.atlassian.net/browse/KFLUXINFRA-3980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ