### PR TITLE
[release-v0.3.x] Security: Fix Go stdlib CVEs (go 1.25.3 → 1.25.12)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/konflux-ci/tekton-kueue
 
-go 1.25.3
+go 1.25.12
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
## Summary

This PR upgrades the Go directive in `go.mod` from `1.25.3` to `1.25.12` to address multiple Go standard library CVEs confirmed by `govulncheck`.

This supersedes #473 (which targeted go1.25.11) and adds the fix for **CVE-2026-42505** (Encrypted Client Hello privacy leak in crypto/tls) fixed in go1.25.12.

### CVE Details — Fixed by this upgrade (symbol-level confirmed)

| GO ID | CVE | Package | Fixed in | Description |
|-------|-----|---------|----------|-------------|
| GO-2026-5856 | CVE-2026-42505 | crypto/tls | go1.25.12 | Encrypted Client Hello privacy leak |
| GO-2026-5039 | CVE-2026-42507 | net/textproto | go1.25.11 | Arbitrary inputs in errors without escaping |
| GO-2026-5038 | CVE-2026-42504 | mime | go1.25.11 | Quadratic complexity in WordDecoder.DecodeHeader |
| GO-2026-5037 | CVE-2026-27145 | crypto/x509 | go1.25.11 | Inefficient candidate hostname parsing |
| GO-2026-4986 | CVE-2026-39820 | net/mail | go1.25.10 | Quadratic string concatenation in consumeComment |
| GO-2026-4982 | CVE-2026-39823 | html/template | go1.25.10 | Bypass of meta content URL escaping causes XSS |
| GO-2026-4980 | CVE-2026-39826 | html/template | go1.25.10 | Escaper bypass leads to XSS |
| GO-2026-4977 | CVE-2026-42499 | net/mail | go1.25.10 | Quadratic string concatenation in consumePhrase |
| GO-2026-4976 | CVE-2026-39825 | net/http/httputil | go1.25.10 | ReverseProxy forwards oversized query params |
| GO-2026-4981 | CVE-2026-33811 | net | go1.25.10 | Crash on long CNAME response |
| GO-2026-4971 | CVE-2026-39836 | net | go1.25.10 | Panic on NUL byte in Dial/LookupPort (Windows) |
| GO-2026-4970 | CVE-2026-39822 | os | go1.25.10 | Root escape via symlink plus trailing slash |
| GO-2026-4947 | CVE-2026-32280 | crypto/x509 | go1.25.9 | Unexpected work during chain building |
| GO-2026-4946 | CVE-2026-32281 | crypto/x509 | go1.25.9 | Inefficient policy validation |
| GO-2026-4918 | CVE-2026-33814 | net/http | go1.25.10 | Infinite loop in HTTP/2 transport |
| GO-2026-4870 | CVE-2026-32283 | crypto/tls | go1.25.9 | Unauthenticated TLS 1.3 KeyUpdate causes DoS |
| GO-2026-4869 | CVE-2026-32288 | archive/tar | go1.25.9 | Unbounded allocation for old GNU sparse |
| GO-2026-4865 | CVE-2026-32289 | html/template | go1.25.9 | JsBraceDepth context tracking bugs (XSS) |
| GO-2026-4864 | CVE-2026-32282 | os | go1.25.9 | TOCTOU permits root escape via Root.Chmod |
| GO-2026-4603 | CVE-2026-27142 | html/template | go1.25.8 | URLs in meta content not escaped |
| GO-2026-4602 | CVE-2026-27139 | os | go1.25.8 | FileInfo can escape from a Root |
| GO-2026-4601 | CVE-2026-25679 | net/url | go1.25.8 | Incorrect parsing of IPv6 host literals |

### Fix Summary

- Updated `go` directive in `go.mod` from `1.25.3` → `1.25.12`
- Ran `go mod tidy && go mod verify` — both pass

### Scan Results (after fix)

`GOTOOLCHAIN=go1.25.12 govulncheck ./...` — **22 stdlib CVEs resolved**. Only 2 non-stdlib vulnerabilities remain (in `github.com/tektoncd/pipeline` — no upstream fix available).

### Test Results

**Status**: ⚠️ Partial — unit/integration tests pass; k8s controller tests and e2e require cluster

### Risk Assessment

**Low** — Go version bump within the same minor line (1.25.x). No API changes; only security patches.

```release-note
Security fix: upgrade Go stdlib from 1.25.3 to 1.25.12 to address 22 symbol-confirmed CVEs (CVE-2026-42505 and others)
```