### PR TITLE
fix: set initial Pending status condition on queued PipelineRuns

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -256,6 +256,11 @@ func runController(args []string) {
 		os.Exit(1)
 	}
 
+	if err = controller.SetupPendingStatusWithManager(mgr); err != nil {
+		setupLog.Error(err, "Failed to setup pending status controller")
+		os.Exit(1)
+	}
+
 	err = controller.SetupIndexer(ctx, mgr.GetFieldIndexer())
 	if err != nil {
 		setupLog.Error(err, "Failed to setup the indexer")

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -78,3 +78,10 @@ rules:
   - pipelineruns/finalizers
   verbs:
   - update
+- apiGroups:
+  - tekton.dev
+  resources:
+  - pipelineruns/status
+  verbs:
+  - patch
+  - update

--- a/internal/controller/pipelinerun_status_reconciler.go
+++ b/internal/controller/pipelinerun_status_reconciler.go
@@ -1,0 +1,81 @@
+package controller
+
+import (
+	"context"
+
+	"github.com/konflux-ci/tekton-kueue/pkg/common"
+	tekv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kapi "knative.dev/pkg/apis"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// +kubebuilder:rbac:groups="tekton.dev",resources=pipelineruns/status,verbs=update;patch
+
+// pipelineRunStatusReconciler watches PipelineRuns and sets a Succeeded=Unknown
+// condition with reason "PipelineRunPending" on runs that are suspended
+// (spec.status=PipelineRunPending) but have no status.conditions yet. Tekton's
+// controller skips PipelineRuns with spec.managedBy set, so without this
+// reconciler the status stays blank in CLI and UI tools until MultiKueue admits
+// the workload and dispatches it to a spoke cluster.
+type pipelineRunStatusReconciler struct {
+	client client.Client
+}
+
+func (r *pipelineRunStatusReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	var plr tekv1.PipelineRun
+	if err := r.client.Get(ctx, req.NamespacedName, &plr); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if plr.Spec.ManagedBy == nil || *plr.Spec.ManagedBy != common.ManagedByMultiKueueLabel {
+		return ctrl.Result{}, nil
+	}
+
+	if plr.Spec.Status != tekv1.PipelineRunSpecStatusPending {
+		return ctrl.Result{}, nil
+	}
+
+	if plr.Status.GetCondition(kapi.ConditionSucceeded) != nil {
+		return ctrl.Result{}, nil
+	}
+
+	plr.Status.SetCondition(&kapi.Condition{
+		Type:               kapi.ConditionSucceeded,
+		Status:             corev1.ConditionUnknown,
+		Reason:             "PipelineRunPending",
+		Message:            "PipelineRun is pending, waiting for MultiKueue admission",
+		LastTransitionTime: kapi.VolatileTime{Inner: metav1.Now()},
+	})
+
+	log.V(2).Info("Setting PipelineRunPending status condition")
+	return ctrl.Result{}, r.client.Status().Update(ctx, &plr)
+}
+
+// needsPendingStatusCondition returns true for PipelineRuns that are
+// MultiKueue-managed, pending, and likely missing a status condition.
+func needsPendingStatusCondition(o client.Object) bool {
+	plr, ok := o.(*tekv1.PipelineRun)
+	if !ok {
+		return false
+	}
+	return plr.Spec.ManagedBy != nil &&
+		*plr.Spec.ManagedBy == common.ManagedByMultiKueueLabel &&
+		plr.Spec.Status == tekv1.PipelineRunSpecStatusPending
+}
+
+// SetupPendingStatusWithManager registers the pending-status reconciler with the manager.
+func SetupPendingStatusWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("PipelineRunStatus").
+		For(&tekv1.PipelineRun{}, builder.WithPredicates(
+			predicate.NewPredicateFuncs(needsPendingStatusCondition),
+		)).
+		Complete(&pipelineRunStatusReconciler{client: mgr.GetClient()})
+}

--- a/internal/controller/pipelinerun_status_reconciler_test.go
+++ b/internal/controller/pipelinerun_status_reconciler_test.go
@@ -1,0 +1,285 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/konflux-ci/tekton-kueue/pkg/common"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	tekv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	kapi "knative.dev/pkg/apis"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+var _ = Describe("pipelineRunStatusReconciler", func() {
+	var (
+		reconciler *pipelineRunStatusReconciler
+		s          *runtime.Scheme
+		nsName     types.NamespacedName
+	)
+
+	BeforeEach(func() {
+		s = runtime.NewScheme()
+		Expect(tekv1.AddToScheme(s)).To(Succeed())
+
+		nsName = types.NamespacedName{
+			Name:      "test-plr",
+			Namespace: "default",
+		}
+	})
+
+	Describe("Reconcile", func() {
+		It("should return success when PipelineRun is not found", func(ctx context.Context) {
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(s).
+				Build()
+			reconciler = &pipelineRunStatusReconciler{client: fakeClient}
+
+			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: nsName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(ctrl.Result{}))
+		})
+
+		It("should skip PipelineRun that is not pending", func(ctx context.Context) {
+			plr := &tekv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-plr",
+					Namespace: "default",
+				},
+				Spec: tekv1.PipelineRunSpec{
+					ManagedBy: ptr.To(common.ManagedByMultiKueueLabel),
+				},
+			}
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(s).
+				WithStatusSubresource(&tekv1.PipelineRun{}).
+				WithObjects(plr).
+				Build()
+			reconciler = &pipelineRunStatusReconciler{client: fakeClient}
+
+			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: nsName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(ctrl.Result{}))
+
+			var updated tekv1.PipelineRun
+			Expect(fakeClient.Get(ctx, nsName, &updated)).To(Succeed())
+			Expect(updated.Status.Conditions).To(BeEmpty())
+		})
+
+		It("should skip PipelineRun that already has a Succeeded condition", func(ctx context.Context) {
+			plr := &tekv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-plr",
+					Namespace: "default",
+				},
+				Spec: tekv1.PipelineRunSpec{
+					Status:    tekv1.PipelineRunSpecStatusPending,
+					ManagedBy: ptr.To(common.ManagedByMultiKueueLabel),
+				},
+			}
+			plr.Status.Conditions = []kapi.Condition{
+				{
+					Type:   kapi.ConditionSucceeded,
+					Status: corev1.ConditionUnknown,
+					Reason: "Running",
+				},
+			}
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(s).
+				WithStatusSubresource(&tekv1.PipelineRun{}).
+				WithObjects(plr).
+				Build()
+			reconciler = &pipelineRunStatusReconciler{client: fakeClient}
+
+			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: nsName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(ctrl.Result{}))
+
+			var updated tekv1.PipelineRun
+			Expect(fakeClient.Get(ctx, nsName, &updated)).To(Succeed())
+			Expect(updated.Status.GetCondition(kapi.ConditionSucceeded).Reason).To(Equal("Running"))
+		})
+
+		It("should skip pending PipelineRun without managedBy", func(ctx context.Context) {
+			plr := &tekv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-plr",
+					Namespace: "default",
+				},
+				Spec: tekv1.PipelineRunSpec{
+					Status: tekv1.PipelineRunSpecStatusPending,
+				},
+			}
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(s).
+				WithStatusSubresource(&tekv1.PipelineRun{}).
+				WithObjects(plr).
+				Build()
+			reconciler = &pipelineRunStatusReconciler{client: fakeClient}
+
+			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: nsName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(ctrl.Result{}))
+
+			var updated tekv1.PipelineRun
+			Expect(fakeClient.Get(ctx, nsName, &updated)).To(Succeed())
+			Expect(updated.Status.Conditions).To(BeEmpty())
+		})
+
+		It("should skip pending PipelineRun with non-MultiKueue managedBy", func(ctx context.Context) {
+			plr := &tekv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-plr",
+					Namespace: "default",
+				},
+				Spec: tekv1.PipelineRunSpec{
+					Status:    tekv1.PipelineRunSpecStatusPending,
+					ManagedBy: ptr.To("some-other-controller"),
+				},
+			}
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(s).
+				WithStatusSubresource(&tekv1.PipelineRun{}).
+				WithObjects(plr).
+				Build()
+			reconciler = &pipelineRunStatusReconciler{client: fakeClient}
+
+			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: nsName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(ctrl.Result{}))
+
+			var updated tekv1.PipelineRun
+			Expect(fakeClient.Get(ctx, nsName, &updated)).To(Succeed())
+			Expect(updated.Status.Conditions).To(BeEmpty())
+		})
+
+		It("should set PipelineRunPending condition on MultiKueue-managed PipelineRun with no conditions", func(ctx context.Context) {
+			plr := &tekv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-plr",
+					Namespace: "default",
+				},
+				Spec: tekv1.PipelineRunSpec{
+					Status:    tekv1.PipelineRunSpecStatusPending,
+					ManagedBy: ptr.To(common.ManagedByMultiKueueLabel),
+				},
+			}
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(s).
+				WithStatusSubresource(&tekv1.PipelineRun{}).
+				WithObjects(plr).
+				Build()
+			reconciler = &pipelineRunStatusReconciler{client: fakeClient}
+
+			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: nsName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(ctrl.Result{}))
+
+			var updated tekv1.PipelineRun
+			Expect(fakeClient.Get(ctx, nsName, &updated)).To(Succeed())
+
+			condition := updated.Status.GetCondition(kapi.ConditionSucceeded)
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Status).To(Equal(corev1.ConditionUnknown))
+			Expect(condition.Reason).To(Equal("PipelineRunPending"))
+			Expect(condition.Message).To(ContainSubstring("pending"))
+		})
+
+		It("should return error when status update fails", func(ctx context.Context) {
+			plr := &tekv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-plr",
+					Namespace: "default",
+				},
+				Spec: tekv1.PipelineRunSpec{
+					Status:    tekv1.PipelineRunSpecStatusPending,
+					ManagedBy: ptr.To(common.ManagedByMultiKueueLabel),
+				},
+			}
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(s).
+				WithStatusSubresource(&tekv1.PipelineRun{}).
+				WithObjects(plr).
+				WithInterceptorFuncs(interceptor.Funcs{
+					SubResourceUpdate: func(_ context.Context, _ client.Client, _ string, _ client.Object, _ ...client.SubResourceUpdateOption) error {
+						return fmt.Errorf("conflict")
+					},
+				}).
+				Build()
+			reconciler = &pipelineRunStatusReconciler{client: fakeClient}
+
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: nsName})
+			Expect(err).To(MatchError("conflict"))
+		})
+	})
+})
+
+var _ = Describe("needsPendingStatusCondition", func() {
+	It("should return false for non-PipelineRun objects", func() {
+		pod := &corev1.Pod{}
+		Expect(needsPendingStatusCondition(pod)).To(BeFalse())
+	})
+
+	It("should return false when managedBy is nil", func() {
+		plr := &tekv1.PipelineRun{
+			Spec: tekv1.PipelineRunSpec{
+				Status: tekv1.PipelineRunSpecStatusPending,
+			},
+		}
+		Expect(needsPendingStatusCondition(plr)).To(BeFalse())
+	})
+
+	It("should return false when managedBy is not MultiKueue", func() {
+		plr := &tekv1.PipelineRun{
+			Spec: tekv1.PipelineRunSpec{
+				Status:    tekv1.PipelineRunSpecStatusPending,
+				ManagedBy: ptr.To("some-other-controller"),
+			},
+		}
+		Expect(needsPendingStatusCondition(plr)).To(BeFalse())
+	})
+
+	It("should return false when not pending", func() {
+		plr := &tekv1.PipelineRun{
+			Spec: tekv1.PipelineRunSpec{
+				ManagedBy: ptr.To(common.ManagedByMultiKueueLabel),
+			},
+		}
+		Expect(needsPendingStatusCondition(plr)).To(BeFalse())
+	})
+
+	It("should return true when MultiKueue-managed and pending", func() {
+		plr := &tekv1.PipelineRun{
+			Spec: tekv1.PipelineRunSpec{
+				Status:    tekv1.PipelineRunSpecStatusPending,
+				ManagedBy: ptr.To(common.ManagedByMultiKueueLabel),
+			},
+		}
+		Expect(needsPendingStatusCondition(plr)).To(BeTrue())
+	})
+})


### PR DESCRIPTION
## What

Sets an initial Succeeded=Unknown / Reason=`PipelineRunPending` status condition on PipelineRuns that are queued by tekton-kueue.

A lightweight status reconciler is registered alongside the existing Kueue workload reconciler in `SetupWithManager`. When it sees a PipelineRun with` spec.status=PipelineRunPending` and empty `status.conditions`, it writes the pending condition via the status subresource.

## Why

The tekton-kueue webhook sets `spec.managedBy=kueue.x-k8s.io/multikueue` on every PipelineRun. Tekton's own controller filters out any PipelineRun whose `managedBy` is not `tekton.dev/pipeline`, so it never reconciles these runs and never populates status.conditions.

Since `kubectl get pipelinerun`, `tkn`/`opc`, and the OpenShift Console UI all read `status.conditions` to display status, queued PipelineRuns show a blank/--- status instead of Pending - making it look like the run is broken rather than waiting for admission.

## Changes

- **internal/controller/pipelinerun_controller.go**: Added `pipelineRunStatusReconciler` and registered it in `SetupWithManager`. Added RBAC marker for pipelineruns/status.
- **internal/controller/pipelinerun_controller_test.go**: Tests covering all reconciler paths (not found, not pending, already has condition, sets condition, update failure).
- **config/rbac/role.yaml**: Auto-generated - adds patch/update on pipelineruns/status.

## Verification

- [x] `make lint` passes
- [x] `make test` passes
- [x] Tested with `tekton-kueue mutate` CLI (if CEL/webhook changes)
- [x] `make manifests` and `make generate` run cleanly (if API/RBAC changes)