### PR TITLE
feat(cel): add managedBy() and multiKueue() CEL functions for routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,8 @@ resource-aware scheduling via admission webhook and CEL-based mutations.
 - `internal/controller/` — PipelineRun → Workload reconciler.
 - `internal/webhook/` — admission webhook with CEL mutation engine.
 - `internal/cel/` — CEL functions: `annotation()`, `label()`, `priority()`,
-  `resource()` plus convenience vars (`plrNamespace`, `pacEventType`).
+  `resource()`, `managedBy()`, `multiKueue()` plus convenience vars
+  (`plrNamespace`, `pacEventType`).
 - `pkg/` — `mutate` (CLI logic), `common` (utilities), `config` (ConfigMap).
 - `config/` — Kustomize manifests; `test/e2e/` — e2e tests.
 
@@ -39,7 +40,9 @@ resource-aware scheduling via admission webhook and CEL-based mutations.
 - Kubebuilder scaffolded — run `make manifests` and `make generate` after
   modifying API types or RBAC markers.
 - CEL `resource()` values with same key are summed; rejects negatives.
-- MultiKueue mode via `multiKueueOverride: true` in ConfigMap.
+- MultiKueue routing via CEL: `multiKueue()` or `multiKueue(queueName)` in
+  expressions. `managedBy(value)` for custom controller routing. The boolean
+  `multiKueueOverride: true` still works for backward compatibility.
 - `mutate` CLI previews webhook behavior offline — use before production.
 - Coverage instrumentation toggled via `ENABLE_COVERAGE=true`.
 - All changes via PR; review required.

--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller
 ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}')
 GOLANGCI_LINT_VERSION ?= v2.7.2
 KUEUE_VERSION ?= $(shell ./hack/get-kueue-version.sh)
-TEKTON_VERSION ?= v0.70.0
+TEKTON_VERSION ?= v1.12.2
 CERT_MANAGER_VERSION ?= v1.19.2
 
 .PHONY: kustomize
@@ -248,7 +248,7 @@ kueue:
 
 .PHONY: tekton
 tekton:
-	$(KUBECTL) apply --server-side -f https://storage.googleapis.com/tekton-releases/pipeline/previous/$(TEKTON_VERSION)/release.yaml
+	$(KUBECTL) apply --server-side -f https://github.com/tektoncd/pipeline/releases/download/$(TEKTON_VERSION)/release.yaml
 	$(KUBECTL) wait --for=condition=Available deployment --all -n tekton-pipelines --timeout=300s
 
 .PHONY: cert-manager

--- a/README.md
+++ b/README.md
@@ -138,6 +138,32 @@ data:
 ```
 The controller will automatically load the configuration from this `ConfigMap`.
 
+#### CEL-Based Routing (Alternative)
+
+For conditional per-PipelineRun routing, use the CEL `multiKueue()` function instead of the boolean `multiKueueOverride`. This lets you route only specific PipelineRuns to MultiKueue based on labels, namespace, or other properties:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tekton-kueue-config
+  namespace: tekton-kueue-system
+data:
+  config.yaml: |
+    queueName: default-queue
+    cel:
+      expressions:
+        # Route build pipelines to spoke cluster via MultiKueue,
+        # keep everything else on the hub
+        - |
+          has(pipelineRun.metadata.labels) &&
+          "pipeline-type" in pipelineRun.metadata.labels &&
+          pipelineRun.metadata.labels["pipeline-type"] == "build" ?
+            [multiKueue("multikueue-queue")] : []
+```
+
+> **Note:** When using CEL routing functions (`managedBy()`, `multiKueue()`), do not set `multiKueueOverride: true`. The boolean sets `Spec.ManagedBy` for all PipelineRuns unconditionally *before* CEL expressions are evaluated, which prevents conditional per-PipelineRun routing. Use `multiKueueOverride` only when *all* PipelineRuns should be routed to MultiKueue.
+
 ## Command Line Interface
 
 The `tekton-kueue` binary provides several subcommands:
@@ -260,6 +286,25 @@ cel:
     - 'plrNamespace == "production" ? label("environment", "prod") : label("environment", "dev")'
     - 'pacEventType == "push" ? annotation("trigger", "push-event") : annotation("trigger", "other-event")'
     - 'pacTestEventType != "" ? label("test-type", pacTestEventType) : label("test-type", "none")'
+    
+    # managedBy - set Spec.ManagedBy to a custom controller (standalone example)
+    - 'managedBy("tekton.dev/pipeline")'
+    
+    # multiKueue - route to spoke cluster via MultiKueue (standalone example)
+    - 'multiKueue()'
+    
+    # multiKueue with queue - route to spoke AND override queue name (standalone example)
+    - 'multiKueue("multikueue-queue")'
+```
+
+> **Note:** `managedBy()`, `multiKueue()`, and `multiKueue("queueName")` all set `Spec.ManagedBy`. Using more than one unconditionally in the same config does not make sense — the last one silently overrides the others. Use them in conditional expressions (ternaries) for per-PipelineRun routing, or pick a single routing strategy.
+
+```yaml
+cel:
+  expressions:
+    # Conditional routing - builds to spoke, releases stay on hub
+    - 'has(pipelineRun.metadata.labels) && "pipeline-type" in pipelineRun.metadata.labels && pipelineRun.metadata.labels["pipeline-type"] == "build" ? [multiKueue("multikueue-queue")] : []'
+    - 'has(pipelineRun.metadata.labels) && "pipeline-type" in pipelineRun.metadata.labels && pipelineRun.metadata.labels["pipeline-type"] == "release" ? [managedBy("tekton.dev/pipeline")] : []'
     
     # Multiline CEL expression for multiple mutations
     # This expression applies several annotations and labels in one go

--- a/internal/cel/compiler.go
+++ b/internal/cel/compiler.go
@@ -58,6 +58,8 @@ func createCELEnvironment() (*cel.Env, error) {
 		createMutationFunction("label", MutationTypeLabel, mutationRequestType),
 		createResourceMutationFunction("resource", MutationTypeResource, mutationRequestType),
 		createPriorityMutationFunction("priority", mutationRequestType),
+		createManagedByFunction("managedBy", mutationRequestType),
+		createMultiKueueFunction("multiKueue", mutationRequestType),
 		// Add string manipulation functions
 		createReplaceFunction("replace"),
 
@@ -211,6 +213,84 @@ func createPriorityMutationFunction(name string, returnType *cel.Type) cel.EnvOp
 					"value": value,
 				}
 
+				return types.NewStringInterfaceMap(types.DefaultTypeAdapter, mutationMap)
+			}),
+		),
+	)
+}
+
+// createManagedByFunction creates a CEL function that sets the PipelineRun's managedBy field to any value.
+// Usage: managedBy("my-custom-controller.io")
+func createManagedByFunction(name string, returnType *cel.Type) cel.EnvOption {
+	return cel.Function(
+		name,
+		cel.Overload(
+			name+"_string_to_mutation",
+			[]*cel.Type{cel.StringType},
+			returnType,
+			cel.UnaryBinding(func(val ref.Val) ref.Val {
+				value, valueOk := val.Value().(string)
+				if !valueOk {
+					return types.NewErr("%s function requires string argument", name)
+				}
+				if value == "" {
+					return types.NewErr("%s value cannot be empty", name)
+				}
+
+				mutationMap := map[string]interface{}{
+					"type":  string(MutationTypeManagedBy),
+					"key":   "managedBy",
+					"value": value,
+				}
+				return types.NewStringInterfaceMap(types.DefaultTypeAdapter, mutationMap)
+			}),
+		),
+	)
+}
+
+// createMultiKueueFunction creates a CEL function with two overloads for MultiKueue routing.
+// Both overloads return the same map<string, any> type (MutationTypeMultiKueue).
+// Zero-arg: multiKueue() — sets managedBy to the MultiKueue value.
+// Single-arg: multiKueue(queueName) — sets managedBy AND overrides the queue label.
+// The queue label expansion is handled at apply time in mutate().
+func createMultiKueueFunction(name string, returnType *cel.Type) cel.EnvOption {
+	return cel.Function(
+		name,
+		cel.Overload(
+			name+"_to_mutation",
+			[]*cel.Type{},
+			returnType,
+			cel.FunctionBinding(func(args ...ref.Val) ref.Val {
+				mutationMap := map[string]interface{}{
+					"type":  string(MutationTypeMultiKueue),
+					"key":   "managedBy", // required by evaluator but unused — mutator hardcodes Spec.ManagedBy
+					"value": "",
+				}
+				return types.NewStringInterfaceMap(types.DefaultTypeAdapter, mutationMap)
+			}),
+		),
+		cel.Overload(
+			name+"_string_to_mutation",
+			[]*cel.Type{cel.StringType},
+			returnType,
+			cel.UnaryBinding(func(val ref.Val) ref.Val {
+				queueName, queueOk := val.Value().(string)
+				if !queueOk {
+					return types.NewErr("%s function requires string argument for queue name", name)
+				}
+				if queueName == "" {
+					return types.NewErr("%s queue name cannot be empty", name)
+				}
+
+				if err := validateLabelValue(queueName); err != nil {
+					return types.NewErr("%s queue name validation failed: %v", name, err)
+				}
+
+				mutationMap := map[string]interface{}{
+					"type":  string(MutationTypeMultiKueue),
+					"key":   "managedBy", // required by evaluator but unused — mutator hardcodes Spec.ManagedBy
+					"value": queueName,
+				}
 				return types.NewStringInterfaceMap(types.DefaultTypeAdapter, mutationMap)
 			}),
 		),

--- a/internal/cel/compiler_test.go
+++ b/internal/cel/compiler_test.go
@@ -34,6 +34,10 @@ func TestCompileCELPrograms_TypeSafety(t *testing.T) {
 				`resource("example.com/cpu", 1000)`,
 				`[annotation("key1", "value1"), label("key2", "value2")]`,
 				`priority("high")`,
+				`managedBy("custom-controller.io")`,
+				`multiKueue()`,
+				`multiKueue("mk-queue")`,
+				`[multiKueue(), annotation("k", "v")]`,
 			},
 			expectErr: false,
 		},
@@ -156,6 +160,21 @@ func TestValidateExpressionReturnType_ValidCases(t *testing.T) {
 			name:        "valid priority in list",
 			expression:  `[priority("medium"), annotation("queue", "default")]`,
 			description: "Returns list<map<string, any>> with priority and annotation",
+		},
+		{
+			name:        "valid managedBy function",
+			expression:  `managedBy("custom-value")`,
+			description: "Returns map<string, any> representing managedBy MutationRequest",
+		},
+		{
+			name:        "valid multiKueue function",
+			expression:  `multiKueue()`,
+			description: "Returns map<string, any> representing multiKueue MutationRequest",
+		},
+		{
+			name:        "valid multiKueue with queue",
+			expression:  `multiKueue("mk-queue")`,
+			description: "Returns map<string, any> representing multiKueue MutationRequest with queue",
 		},
 		{
 			name:        "valid single resource",
@@ -688,6 +707,197 @@ func TestResourceFunction_ErrorCases(t *testing.T) {
 			g.Expect(err.Error()).To(ContainSubstring(tt.errorMsg), "Error message should contain expected text")
 		})
 	}
+}
+
+func TestManagedByFunction(t *testing.T) {
+	g := NewWithT(t)
+
+	env, err := createCELEnvironment()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	tests := []struct {
+		name       string
+		expression string
+		expected   map[string]interface{}
+	}{
+		{
+			name:       "managedBy with custom value",
+			expression: `managedBy("my-custom-controller.io")`,
+			expected: map[string]interface{}{
+				"type":  "managedBy",
+				"key":   "managedBy",
+				"value": "my-custom-controller.io",
+			},
+		},
+		{
+			name:       "managedBy with multikueue value",
+			expression: `managedBy("kueue.x-k8s.io/multikueue")`,
+			expected: map[string]interface{}{
+				"type":  "managedBy",
+				"key":   "managedBy",
+				"value": "kueue.x-k8s.io/multikueue",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			ast, issues := env.Compile(tt.expression)
+			g.Expect(issues.Err()).NotTo(HaveOccurred())
+
+			program, err := env.Program(ast)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			result, _, err := program.Eval(map[string]interface{}{})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(result).NotTo(BeNil())
+
+			resultMap, ok := result.Value().(map[string]interface{})
+			g.Expect(ok).To(BeTrue(), "Result should be a map")
+			g.Expect(resultMap).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestManagedByFunction_ErrorCases(t *testing.T) {
+	g := NewWithT(t)
+
+	env, err := createCELEnvironment()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	tests := []struct {
+		name       string
+		expression string
+		errorMsg   string
+	}{
+		{
+			name:       "managedBy with empty value",
+			expression: `managedBy("")`,
+			errorMsg:   "managedBy value cannot be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			ast, issues := env.Compile(tt.expression)
+			g.Expect(issues.Err()).NotTo(HaveOccurred())
+
+			program, err := env.Program(ast)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			_, _, err = program.Eval(map[string]interface{}{})
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(err.Error()).To(ContainSubstring(tt.errorMsg))
+		})
+	}
+}
+
+func TestMultiKueueFunction(t *testing.T) {
+	g := NewWithT(t)
+
+	env, err := createCELEnvironment()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	t.Run("zero-arg returns multiKueue mutation without queue", func(t *testing.T) {
+		g := NewWithT(t)
+
+		ast, issues := env.Compile(`multiKueue()`)
+		g.Expect(issues.Err()).NotTo(HaveOccurred())
+
+		program, err := env.Program(ast)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		result, _, err := program.Eval(map[string]interface{}{})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result).NotTo(BeNil())
+
+		resultMap, ok := result.Value().(map[string]interface{})
+		g.Expect(ok).To(BeTrue(), "Result should be a map")
+		g.Expect(resultMap).To(Equal(map[string]interface{}{
+			"type":  "multiKueue",
+			"key":   "managedBy",
+			"value": "",
+		}))
+	})
+
+	t.Run("single-arg returns multiKueue mutation with queue", func(t *testing.T) {
+		g := NewWithT(t)
+
+		ast, issues := env.Compile(`multiKueue("mk-queue")`)
+		g.Expect(issues.Err()).NotTo(HaveOccurred())
+
+		program, err := env.Program(ast)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		result, _, err := program.Eval(map[string]interface{}{})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result).NotTo(BeNil())
+
+		resultMap, ok := result.Value().(map[string]interface{})
+		g.Expect(ok).To(BeTrue(), "Result should be a map")
+		g.Expect(resultMap).To(Equal(map[string]interface{}{
+			"type":  "multiKueue",
+			"key":   "managedBy",
+			"value": "mk-queue",
+		}))
+	})
+
+	t.Run("both overloads are composable in ternary", func(t *testing.T) {
+		g := NewWithT(t)
+
+		_, err := CompileCELPrograms([]string{
+			`true ? multiKueue() : multiKueue("queue")`,
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+	})
+
+	t.Run("both overloads composable in list", func(t *testing.T) {
+		g := NewWithT(t)
+
+		_, err := CompileCELPrograms([]string{
+			`[multiKueue("mk-queue"), annotation("k", "v")]`,
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+	})
+}
+
+func TestMultiKueueFunction_ErrorCases(t *testing.T) {
+	g := NewWithT(t)
+
+	env, err := createCELEnvironment()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	t.Run("single-arg with empty queue name", func(t *testing.T) {
+		g := NewWithT(t)
+
+		ast, issues := env.Compile(`multiKueue("")`)
+		g.Expect(issues.Err()).NotTo(HaveOccurred())
+
+		program, err := env.Program(ast)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		_, _, err = program.Eval(map[string]interface{}{})
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("multiKueue queue name cannot be empty"))
+	})
+
+	t.Run("single-arg with invalid label value", func(t *testing.T) {
+		g := NewWithT(t)
+
+		ast, issues := env.Compile(`multiKueue("invalid value!")`)
+		g.Expect(issues.Err()).NotTo(HaveOccurred())
+
+		program, err := env.Program(ast)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		_, _, err = program.Eval(map[string]interface{}{})
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("queue name validation failed"))
+	})
 }
 
 func TestResourceFunctionIntegration(t *testing.T) {

--- a/internal/cel/doc.go
+++ b/internal/cel/doc.go
@@ -12,7 +12,8 @@
 //
 //   - Input: *tekton.PipelineRun (strongly typed and validated)
 //   - Output: []MutationRequest (validated structure and content)
-//   - Functions: annotation(key, value), label(key, value), and priority(value)
+//   - Functions: annotation(key, value), label(key, value), priority(value), resource(key, count),
+//     managedBy(value), multiKueue() / multiKueue(queueName), replace(source, search, replacement)
 //   - Expressions: Single mutations or lists of mutations
 //
 // # Basic Usage
@@ -74,6 +75,20 @@
 //   - priority(value: string) -> MutationRequest
 //     Creates a label mutation with key "kueue.x-k8s.io/priority-class" and the specified value
 //
+//   - managedBy(value: string) -> MutationRequest
+//     Sets the PipelineRun's Spec.ManagedBy field to the specified value.
+//     Use for custom controller routing (e.g., managedBy("tekton.dev/pipeline"))
+//
+//   - multiKueue() -> MutationRequest
+//     Sets Spec.ManagedBy to "kueue.x-k8s.io/multikueue", routing the PipelineRun
+//     to a spoke cluster via Kueue's MultiKueue dispatch
+//
+//   - multiKueue(queueName: string) -> MutationRequest
+//     Sets Spec.ManagedBy to "kueue.x-k8s.io/multikueue" AND overrides the
+//     "kueue.x-k8s.io/queue-name" label to the specified queue. Both changes
+//     are applied from a single mutation at apply time. Use when the MultiKueue
+//     queue differs from the default queue.
+//
 //   - replace(source: string, search: string, replacement: string) -> string
 //     Replaces all occurrences of search string with replacement string in the source string
 //
@@ -103,6 +118,20 @@
 //	              pipelineRun.spec.params.filter(p, p.name == "build-platforms")[0].value.map(
 //	                  p, annotation("kueue.konflux-ci.dev/requests-" + p, "1")
 //	              ) : []`
+//
+// CEL-based routing with multiKueue — route builds to spoke, releases to hub:
+//
+//	expression := `has(pipelineRun.metadata.labels) &&
+//	              "pipeline-type" in pipelineRun.metadata.labels &&
+//	              pipelineRun.metadata.labels["pipeline-type"] == "build" ?
+//	              multiKueue("multikueue-queue") : []`
+//
+// Set a custom managedBy for release pipelines:
+//
+//	expression := `has(pipelineRun.metadata.labels) &&
+//	              "pipeline-type" in pipelineRun.metadata.labels &&
+//	              pipelineRun.metadata.labels["pipeline-type"] == "release" ?
+//	              [managedBy("tekton.dev/pipeline")] : []`
 //
 // Using string manipulation with replace function:
 //

--- a/internal/cel/mutator.go
+++ b/internal/cel/mutator.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/konflux-ci/tekton-kueue/pkg/common"
 	tekv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"k8s.io/utils/ptr"
 )
 
 // CELMutator applies mutations to PipelineRun objects based on compiled CEL programs.
@@ -161,6 +163,16 @@ func mutate(pipelineRun *tekv1.PipelineRun, mutation *MutationRequest) (*tekv1.P
 
 		// Store the summed value back as string
 		pipelineRun.Annotations[mutation.Key] = strconv.Itoa(newValue)
+	case MutationTypeManagedBy:
+		pipelineRun.Spec.ManagedBy = ptr.To(mutation.Value)
+	case MutationTypeMultiKueue:
+		pipelineRun.Spec.ManagedBy = ptr.To(common.ManagedByMultiKueueLabel)
+		if mutation.Value != "" {
+			if pipelineRun.Labels == nil {
+				pipelineRun.Labels = make(map[string]string)
+			}
+			pipelineRun.Labels[common.QueueLabel] = mutation.Value
+		}
 	}
 	return pipelineRun, nil
 }

--- a/internal/cel/mutator_test.go
+++ b/internal/cel/mutator_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	tekv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 // Common test constants to reduce duplication
@@ -785,6 +786,102 @@ func TestCELMutator_Mutate(t *testing.T) {
 			},
 			expectErr: false,
 		},
+		{
+			name: "managedBy with custom value",
+			expressions: []string{
+				`managedBy("my-custom-controller.io")`,
+			},
+			initialLabels:       nil,
+			initialAnnotations:  nil,
+			expectedLabels:      nil,
+			expectedAnnotations: nil,
+			expectErr:           false,
+		},
+		{
+			name: "multiKueue zero-arg sets managedBy",
+			expressions: []string{
+				`multiKueue()`,
+			},
+			initialLabels:       nil,
+			initialAnnotations:  nil,
+			expectedLabels:      nil,
+			expectedAnnotations: nil,
+			expectErr:           false,
+		},
+		{
+			name: "multiKueue with queue name sets managedBy and queue label",
+			expressions: []string{
+				`multiKueue("mk-queue")`,
+			},
+			initialLabels:      nil,
+			initialAnnotations: nil,
+			expectedLabels: map[string]string{
+				"kueue.x-k8s.io/queue-name": "mk-queue",
+			},
+			expectedAnnotations: nil,
+			expectErr:           false,
+		},
+		{
+			name: "multiKueue combined with other mutations",
+			expressions: []string{
+				`[multiKueue(), resource("cpu", 2)]`,
+			},
+			initialLabels:      nil,
+			initialAnnotations: nil,
+			expectedLabels:     nil,
+			expectedAnnotations: map[string]string{
+				"kueue.konflux-ci.dev/requests-cpu": "2",
+			},
+			expectErr: false,
+		},
+		{
+			name: "conditional multiKueue - build event routes to multikueue",
+			expressions: []string{
+				`pacEventType == "build" ? multiKueue() : annotation("routing", "hub")`,
+			},
+			initialLabels: map[string]string{
+				"pipelinesascode.tekton.dev/event-type": "build",
+			},
+			initialAnnotations: nil,
+			expectedLabels: map[string]string{
+				"pipelinesascode.tekton.dev/event-type": "build",
+			},
+			expectedAnnotations: nil,
+			expectErr:           false,
+		},
+		{
+			name: "conditional multiKueue - release event stays on hub",
+			expressions: []string{
+				`pacEventType == "build" ? multiKueue() : annotation("routing", "hub")`,
+			},
+			initialLabels: map[string]string{
+				"pipelinesascode.tekton.dev/event-type": "release",
+			},
+			initialAnnotations: nil,
+			expectedLabels: map[string]string{
+				"pipelinesascode.tekton.dev/event-type": "release",
+			},
+			expectedAnnotations: map[string]string{
+				"routing": "hub",
+			},
+			expectErr: false,
+		},
+		{
+			name: "conditional multiKueue with queue override",
+			expressions: []string{
+				`pacEventType == "build" ? multiKueue("mk-queue") : annotation("routing", "hub")`,
+			},
+			initialLabels: map[string]string{
+				"pipelinesascode.tekton.dev/event-type": "build",
+			},
+			initialAnnotations: nil,
+			expectedLabels: map[string]string{
+				"pipelinesascode.tekton.dev/event-type": "build",
+				"kueue.x-k8s.io/queue-name":             "mk-queue",
+			},
+			expectedAnnotations: nil,
+			expectErr:           false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -847,6 +944,112 @@ func TestCELMutator_Mutate(t *testing.T) {
 
 			// Verify annotations
 			g.Expect(pipelineRun.Annotations).To(Equal(tt.expectedAnnotations))
+		})
+	}
+}
+
+func TestCELMutator_Mutate_ManagedBy(t *testing.T) {
+	tests := []struct {
+		name                string
+		expressions         []string
+		initialLabels       map[string]string
+		expectedManagedBy   *string
+		expectedLabels      map[string]string
+		expectedAnnotations map[string]string
+	}{
+		{
+			name:              "managedBy sets Spec.ManagedBy",
+			expressions:       []string{`managedBy("my-custom-controller.io")`},
+			expectedManagedBy: ptr.To("my-custom-controller.io"),
+		},
+		{
+			name:              "multiKueue sets Spec.ManagedBy to multikueue value",
+			expressions:       []string{`multiKueue()`},
+			expectedManagedBy: ptr.To("kueue.x-k8s.io/multikueue"),
+		},
+		{
+			name:              "multiKueue with queue sets both managedBy and queue label",
+			expressions:       []string{`multiKueue("mk-queue")`},
+			expectedManagedBy: ptr.To("kueue.x-k8s.io/multikueue"),
+			expectedLabels: map[string]string{
+				"kueue.x-k8s.io/queue-name": "mk-queue",
+			},
+		},
+		{
+			name:        "conditional multiKueue - true branch sets managedBy",
+			expressions: []string{`pacEventType == "build" ? multiKueue() : annotation("routing", "hub")`},
+			initialLabels: map[string]string{
+				"pipelinesascode.tekton.dev/event-type": "build",
+			},
+			expectedManagedBy: ptr.To("kueue.x-k8s.io/multikueue"),
+		},
+		{
+			name:        "conditional multiKueue - false branch does not set managedBy",
+			expressions: []string{`pacEventType == "build" ? multiKueue() : annotation("routing", "hub")`},
+			initialLabels: map[string]string{
+				"pipelinesascode.tekton.dev/event-type": "release",
+			},
+			expectedManagedBy: nil,
+			expectedAnnotations: map[string]string{
+				"routing": "hub",
+			},
+		},
+		{
+			name:              "multiKueue combined with other mutations",
+			expressions:       []string{`[multiKueue(), resource("cpu", 2)]`},
+			expectedManagedBy: ptr.To("kueue.x-k8s.io/multikueue"),
+			expectedAnnotations: map[string]string{
+				"kueue.konflux-ci.dev/requests-cpu": "2",
+			},
+		},
+		{
+			name:        "conditional multiKueue with queue - true branch",
+			expressions: []string{`pacEventType == "build" ? multiKueue("mk-queue") : annotation("routing", "hub")`},
+			initialLabels: map[string]string{
+				"pipelinesascode.tekton.dev/event-type": "build",
+			},
+			expectedManagedBy: ptr.To("kueue.x-k8s.io/multikueue"),
+			expectedLabels: map[string]string{
+				"pipelinesascode.tekton.dev/event-type": "build",
+				"kueue.x-k8s.io/queue-name":             "mk-queue",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			pipelineRun := &tekv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pipeline",
+					Namespace: "test-namespace",
+					Labels:    maps.Clone(tt.initialLabels),
+				},
+				Spec: tekv1.PipelineRunSpec{
+					PipelineRef: &tekv1.PipelineRef{Name: "test-pipeline"},
+				},
+			}
+
+			programs, err := CompileCELPrograms(tt.expressions)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			mutator := NewCELMutator(programs)
+			g.Expect(mutator.Mutate(pipelineRun)).To(Succeed())
+
+			if tt.expectedManagedBy != nil {
+				g.Expect(pipelineRun.Spec.ManagedBy).NotTo(BeNil())
+				g.Expect(*pipelineRun.Spec.ManagedBy).To(Equal(*tt.expectedManagedBy))
+			} else {
+				g.Expect(pipelineRun.Spec.ManagedBy).To(BeNil())
+			}
+
+			if tt.expectedLabels != nil {
+				g.Expect(pipelineRun.Labels).To(Equal(tt.expectedLabels))
+			}
+			if tt.expectedAnnotations != nil {
+				g.Expect(pipelineRun.Annotations).To(Equal(tt.expectedAnnotations))
+			}
 		})
 	}
 }

--- a/internal/cel/types.go
+++ b/internal/cel/types.go
@@ -14,6 +14,8 @@ const (
 	MutationTypeAnnotation MutationType = "annotation"
 	MutationTypeLabel      MutationType = "label"
 	MutationTypeResource   MutationType = "resource"
+	MutationTypeManagedBy  MutationType = "managedBy"
+	MutationTypeMultiKueue MutationType = "multiKueue"
 )
 
 // IsValid checks if the mutation type is valid
@@ -28,7 +30,7 @@ func (mt MutationType) String() string {
 
 // ValidTypes returns all valid mutation types
 func ValidTypes() []MutationType {
-	return []MutationType{MutationTypeAnnotation, MutationTypeLabel, MutationTypeResource}
+	return []MutationType{MutationTypeAnnotation, MutationTypeLabel, MutationTypeResource, MutationTypeManagedBy, MutationTypeMultiKueue}
 }
 
 // UnmarshalJSON implements json.Unmarshaler interface with validation
@@ -67,8 +69,11 @@ func (mr *MutationRequest) Validate() error {
 	if mr.Key == "" {
 		return fmt.Errorf("mutation key cannot be empty")
 	}
-	if mr.Value == "" {
+	if mr.Value == "" && mr.Type != MutationTypeMultiKueue {
 		return fmt.Errorf("mutation value cannot be empty")
+	}
+	if mr.Type == MutationTypeManagedBy && mr.Key != "managedBy" {
+		return fmt.Errorf("managedBy mutation must use key %q, got %q", "managedBy", mr.Key)
 	}
 	return nil
 }

--- a/internal/cel/types_test.go
+++ b/internal/cel/types_test.go
@@ -16,6 +16,8 @@ func TestMutationType_IsValid(t *testing.T) {
 		{"valid annotation", MutationTypeAnnotation, true},
 		{"valid label", MutationTypeLabel, true},
 		{"valid resource", MutationTypeResource, true},
+		{"valid managedBy", MutationTypeManagedBy, true},
+		{"valid multiKueue", MutationTypeMultiKueue, true},
 		{"invalid type", MutationType("invalid"), false},
 		{"empty type", MutationType(""), false},
 	}
@@ -53,6 +55,18 @@ func TestMutationType_JSON(t *testing.T) {
 			input:     `"resource"`,
 			expectErr: false,
 			expected:  MutationTypeResource,
+		},
+		{
+			name:      "valid managedBy",
+			input:     `"managedBy"`,
+			expectErr: false,
+			expected:  MutationTypeManagedBy,
+		},
+		{
+			name:      "valid multiKueue",
+			input:     `"multiKueue"`,
+			expectErr: false,
+			expected:  MutationTypeMultiKueue,
 		},
 		{
 			name:      "invalid type",
@@ -141,6 +155,43 @@ func TestMutationRequest_Validate(t *testing.T) {
 			},
 			expectErr: true,
 			errMsg:    "mutation value cannot be empty",
+		},
+		{
+			name: "valid managedBy",
+			request: MutationRequest{
+				Type:  MutationTypeManagedBy,
+				Key:   "managedBy",
+				Value: "custom-controller.io",
+			},
+			expectErr: false,
+		},
+		{
+			name: "managedBy with wrong key",
+			request: MutationRequest{
+				Type:  MutationTypeManagedBy,
+				Key:   "wrong-key",
+				Value: "custom-controller.io",
+			},
+			expectErr: true,
+			errMsg:    "managedBy mutation must use key",
+		},
+		{
+			name: "valid multiKueue with queue",
+			request: MutationRequest{
+				Type:  MutationTypeMultiKueue,
+				Key:   "managedBy",
+				Value: "my-queue",
+			},
+			expectErr: false,
+		},
+		{
+			name: "valid multiKueue without queue",
+			request: MutationRequest{
+				Type:  MutationTypeMultiKueue,
+				Key:   "managedBy",
+				Value: "",
+			},
+			expectErr: false,
 		},
 	}
 

--- a/internal/webhook/v1/pipelinerun_webhook_test.go
+++ b/internal/webhook/v1/pipelinerun_webhook_test.go
@@ -327,6 +327,27 @@ var _ = Describe("PipelineRun Webhook", func() {
 					MatchError(ContainSubstring("CEL evaluation failed"))))
 		})
 
+		It("CEL managedBy should override config-level multiKueueOverride", func(ctx context.Context) {
+			programs, err := cel.CompileCELPrograms([]string{`managedBy("my-custom-controller")`})
+			Expect(err).NotTo(HaveOccurred())
+
+			cfg := &config.Config{
+				QueueName:          "test-queue",
+				MultiKueueOverride: true,
+			}
+			cfgStore := &ConfigStore{
+				config:   cfg,
+				mutators: []PipelineRunMutator{cel.NewCELMutator(programs)},
+			}
+
+			defaulter, err = NewCustomDefaulter(cfgStore)
+			Expect(err).NotTo(HaveOccurred())
+			err = defaulter.Default(ctx, plr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*plr.Spec.ManagedBy).To(Equal("my-custom-controller"),
+				"CEL managedBy() should override the config-level multiKueueOverride value")
+		})
+
 		It("should reject a non-pipelinerun object", func(ctx context.Context) {
 			cfg := &config.Config{
 				QueueName: "test-queue",
@@ -459,9 +480,34 @@ var _ = Describe("Zero-value field leak (issue #319)", func() {
 		}
 	})
 
-	// This Test validates the case when PipelineRun Contains all the fields and Webhook is not expected to apply Any patch.
-	// In Such Scenario Handler webhook should set the Patch and PatchType to Nil
-	// Both these values should be sync otherwise Kubernetes will not be able to process the PipelineRun.
+	It("patchFilteringWebhook allows /spec/managedBy patches from CEL managedBy()", func(ctx context.Context) {
+		programs, err := cel.CompileCELPrograms([]string{`managedBy("custom-controller.io")`})
+		Expect(err).NotTo(HaveOccurred())
+
+		cfgStore = &ConfigStore{
+			config:   &config.Config{QueueName: "test-queue"},
+			mutators: []PipelineRunMutator{cel.NewCELMutator(programs)},
+		}
+
+		defaulter, err := NewCustomDefaulter(cfgStore)
+		Expect(err).NotTo(HaveOccurred())
+
+		inner := admission.WithCustomDefaulter(scheme, &tektondevv1.PipelineRun{}, defaulter)
+		filtered := &patchFilteringWebhook{inner: inner}
+
+		resp := filtered.Handle(ctx, makeAdmissionRequest(minimalPipelineRunJSON))
+		Expect(resp.Allowed).To(BeTrue())
+
+		hasManagedByPatch := false
+		for _, p := range resp.Patches {
+			if strings.Contains(p.Path, "managedBy") {
+				hasManagedByPatch = true
+			}
+		}
+		Expect(hasManagedByPatch).To(BeTrue(),
+			"expected /spec/managedBy patch to survive the patch filter")
+	})
+
 	It("patchFilteringWebhook sets Patch and PatchType to nil when there is nothing to patch", func(ctx context.Context) {
 		defaulter, err := NewCustomDefaulter(cfgStore)
 		Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -648,6 +648,43 @@ var _ = Describe("Manager", Ordered, func() {
 
 	})
 
+	Context("CEL managedBy sets Spec.ManagedBy", Ordered, Label("config", "smoke"), func() {
+		managedByValue := "test-controller.example.io"
+		kueueConfig := config.Config{
+			QueueName: "local-queue",
+			CEL: config.CEL{
+				Expressions: []string{
+					fmt.Sprintf(`managedBy("%s")`, managedByValue),
+				},
+			},
+		}
+
+		cfgMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      common.ConfigMapName,
+				Namespace: "tekton-kueue",
+			},
+			Data: map[string]string{},
+		}
+
+		It("should set ManagedBy on created PipelineRun", func(ctx context.Context) {
+			cfgMapData, err := yaml.Marshal(kueueConfig)
+			Expect(err).ToNot(HaveOccurred())
+
+			cfgMap.Data[common.ConfigKey] = string(cfgMapData)
+
+			err = k8sClient.Update(ctx, cfgMap)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() *string {
+				plr := plrTemplate.DeepCopy()
+				err = k8sClient.Create(ctx, plr)
+				Expect(err).NotTo(HaveOccurred())
+				return plr.Spec.ManagedBy
+			}).WithTimeout(time.Duration(30) * time.Second).Should(HaveValue(Equal(managedByValue)))
+		})
+	})
+
 	Context("Ignore Config when ConfigMap is updated with invalid Values", Ordered, Label("config", "smoke"), func() {
 		queueName := "my-ignored-queue"
 		kueueConfig := config.Config{


### PR DESCRIPTION
## What

<!-- Brief description of the change -->

## Why

<!-- Motivation or link to Jira issue, e.g. KFLUXINFRA-1234 -->

## Verification

- [x] `make lint` passes
- [x] `make test` passes
- [x] Tested with `tekton-kueue mutate` CLI (if CEL/webhook changes)
- [x] `make manifests` and `make generate` run cleanly (if API/RBAC changes)
