### PR TITLE
Fix: Pin kind version and node image in E2E workflow

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -92,6 +92,14 @@
       "matchManagers": ["gomod"],
       "matchPackagePatterns": ["^k8s\\.io/"],
       "allowedVersions": "<0.36.0"
+    },
+    {
+      "groupName": "kind cluster tooling",
+      "description": "keep kind binary and node image in sync",
+      "matchDepNames": [
+        "kubernetes-sigs/kind",
+        "kindest/node"
+      ]
     }
   ],
   "customManagers": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -93,5 +93,28 @@
       "matchPackagePatterns": ["^k8s\\.io/"],
       "allowedVersions": "<0.36.0"
     }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update kind binary version in CI workflows",
+      "managerFilePatterns": [
+        ".github/workflows/**"
+      ],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>[a-z-]+)\\s+depName=(?<depName>[^\\s]+)\\n\\s*KIND_VERSION=(?<currentValue>v[^\\s]+)"
+      ],
+      "extractVersionTemplate": "^v(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
+      "description": "Update kind node image in CI workflows",
+      "managerFilePatterns": [
+        ".github/workflows/**"
+      ],
+      "matchStrings": [
+        "kindest/node:(?<currentValue>v[^\\s#]+)\\s*#\\s*renovate:\\s*datasource=(?<datasource>[a-z-]+)\\s+depName=(?<depName>[^\\s]+)\\s+versioning=(?<versioning>[^\\s]+)"
+      ]
+    }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,7 +9,8 @@
     "dockerfile",
     "rpm-lockfile",
     "gomod",
-    "github-actions"
+    "github-actions",
+    "custom.regex"
   ],
   "addLabels": [
     "konflux",
@@ -121,7 +122,7 @@
         ".github/workflows/**"
       ],
       "matchStrings": [
-        "kindest/node:(?<currentValue>v[^\\s#]+)\\s*#\\s*renovate:\\s*datasource=(?<datasource>[a-z-]+)\\s+depName=(?<depName>[^\\s]+)\\s+versioning=(?<versioning>[^\\s]+)"
+        "kindest/node:(?<currentValue>v[^@\\s#]+)@(?<currentDigest>sha256:[a-f0-9]+)\\s*#\\s*renovate:\\s*datasource=(?<datasource>[a-z-]+)\\s+depName=(?<depName>[^\\s]+)\\s+versioning=(?<versioning>[^\\s]+)"
       ]
     }
   ]

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -20,9 +20,9 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Install the latest version of kind
+      - name: Install pinned kind version
         run: |
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.32.0/kind-linux-amd64
           chmod +x ./kind
           sudo mv ./kind /usr/local/bin/kind
 
@@ -30,7 +30,7 @@ jobs:
         run: kind version
 
       - name: Create kind cluster
-        run: kind create cluster
+        run: kind create cluster --image kindest/node:v1.35.5
         env:
           KIND_EXPERIMENTAL_PROVIDER: podman
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -21,8 +21,13 @@ jobs:
           go-version-file: go.mod
 
       - name: Install pinned kind version
+        # Renovate updates KIND_VERSION automatically; only stable releases are proposed.
+        # If kind and node image are updated independently a version mismatch may cause
+        # cluster creation to fail, which CI will catch before merge.
         run: |
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.32.0/kind-linux-amd64
+          # renovate: datasource=github-releases depName=kubernetes-sigs/kind
+          KIND_VERSION=v0.32.0
+          curl -Lo ./kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
           chmod +x ./kind
           sudo mv ./kind /usr/local/bin/kind
 
@@ -30,7 +35,7 @@ jobs:
         run: kind version
 
       - name: Create kind cluster
-        run: kind create cluster --image kindest/node:v1.35.5
+        run: kind create cluster --image kindest/node:v1.35.5 # renovate: datasource=docker depName=kindest/node versioning=docker
         env:
           KIND_EXPERIMENTAL_PROVIDER: podman
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -35,7 +35,7 @@ jobs:
         run: kind version
 
       - name: Create kind cluster
-        run: kind create cluster --image kindest/node:v1.35.5 # renovate: datasource=docker depName=kindest/node versioning=docker
+        run: kind create cluster --image kindest/node:v1.35.5@sha256:ce977ae6d65918d0b58a5f8b5e940429c2ce42fa3a5619ec2bbc60b949c0ac95 # renovate: datasource=docker depName=kindest/node versioning=docker
         env:
           KIND_EXPERIMENTAL_PROVIDER: podman
 


### PR DESCRIPTION
## Summary
- Pin kind to v0.32.0 (latest stable) instead of floating `/dl/latest/`
- Pin node image to `kindest/node:v1.35.5`
- Add Renovate annotations so both versions are kept up to date automatically

## Root cause
`kind.sigs.k8s.io/dl/latest/` resolved to `v0.33.0-alpha`, which ships `kindest/node:v1.36.1`. That node image uses an OCI runtime spec version incompatible with the `crun` binary on GitHub Actions ubuntu runners when `KIND_EXPERIMENTAL_PROVIDER=podman`, producing `crun: unknown version specified` (exit 126) at cluster creation.

## Approach
Rather than hardcoding a version that rots, the kind binary version and node image are annotated with Renovate datasource comments:
- **kind binary**: `datasource=github-releases depName=kubernetes-sigs/kind` — Renovate's default semver versioning excludes pre-release tags (`-alpha`, `-beta`, `-rc`), so only stable kind releases are proposed.
- **node image**: `datasource=docker depName=kindest/node` — tracked as a Docker image tag.

Because kind and its node image are not independently versionable, a Renovate update to one without the other could cause a mismatch. This is safe because **CI creates a kind cluster on every PR** — an incompatible pairing fails the E2E workflow before merge, making the mismatch visible and blocking the update.

## Test plan
- [ ] E2E tests pass with pinned versions (CI validates this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)