### PR TITLE
fix(ci): replace version tags with SHA-pinned references in workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -13,10 +13,10 @@ jobs:
       IMG: konflux-ci.dev/tekton-kueue:v0.0.1
     steps:
       - name: Clone the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
 
@@ -73,7 +73,7 @@ jobs:
 
       - name: Upload e2e coverage to Codecov
         if: always()
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           use_oidc: true
           flags: e2e-tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
       id-token: write
     steps:
       - name: Clone the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
 
@@ -26,7 +26,7 @@ jobs:
           make test
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           use_oidc: true
           flags: unit-tests


### PR DESCRIPTION
# Changes

Pin GitHub Actions in CI workflows to commit SHAs to comply with the tektoncd org policy - version tags (`@v4`, `@v5`) are replaced with commit SHAs.

**Actions pinned:**
- `actions/checkout@v4` → `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2)
- `actions/setup-go@v5` → `40f1582b2485089dde7abd97c1529aa768e1baff` (v5.6.0)
- `codecov/codecov-action@v5` → `0fb7174895f61a3b6b78fc075e0cd60383518dac` (v5.5.5)

**Notes**:
- `actions/checkout` is bumped to v6.0.2 to align with the other workflows already in this repo (`agents-md-lint.yaml`, `auto-merge.yaml`, `dep-triage.yaml`).
- `golangci/golangci-lint-action@v8` is left unchanged - it matches the org allowlist pattern `golangci/golangci-lint-action@*`

**Workflows updated:**
- `.github/workflows/test.yml`
- `.github/workflows/lint.yml`
- `.github/workflows/test-e2e.yml`