### PR TITLE
docs: add standard GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,51 @@
+---
+name: Bug Report
+about: Template for bug reports
+labels: kind/bug
+---
+
+# Expected Behavior
+
+# Actual Behavior
+
+# Steps to Reproduce the Problem
+
+1.
+2.
+3.
+
+# Additional Info
+
+- Kubernetes version:
+
+  **Output of `kubectl version`:**
+
+```
+(paste your output here)
+```
+
+- Tekton Pipeline version:
+
+  **Output of `tkn version` or `kubectl get pods -n tekton-pipelines -l app=tekton-pipelines-controller -o=jsonpath='{.items[0].metadata.labels.version}'`:**
+
+```
+(paste your output here)
+```
+
+- Kueue version:
+
+  **Kueue controller image tag or digest:**
+
+```
+(paste your output here)
+```
+
+- Tekton Kueue version:
+
+  **Tekton Kueue controller and webhook image tags or digests:**
+
+```
+(paste your output here)
+```
+
+<!-- Any other additional information, including relevant logs and configuration -->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,13 @@
+---
+name: Feature Request
+about: Template for feature requests
+labels: kind/feature
+---
+
+### Feature request
+
+<!-- Please describe the feature request and why you would like to have it -->
+
+### Use case
+
+<!-- Please add a concrete use case to demonstrate how such a feature would add value for the user. If you don't have a use case for your feature, please remove this section (however providing a good use case increases the likelihood to be picked up) -->

--- a/.github/ISSUE_TEMPLATE/free-form.md
+++ b/.github/ISSUE_TEMPLATE/free-form.md
@@ -1,0 +1,4 @@
+---
+name: Free Form
+about: Create an unstructured issue
+---

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,23 @@
-## What
+<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
 
-<!-- Brief description of the change -->
+# Changes
 
-## Why
+<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
 
-<!-- Motivation or link to Jira issue, e.g. KFLUXINFRA-1234 -->
+# Submitter Checklist
 
-## Verification
+As the author of this PR, please check off the items in this checklist:
 
-- [ ] `make lint` passes
-- [ ] `make test` passes
-- [ ] Tested with `tekton-kueue mutate` CLI (if CEL/webhook changes)
-- [ ] `make manifests` and `make generate` run cleanly (if API/RBAC changes)
+- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
+- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
+- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
+- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
+- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
+- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
+- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release
+
+# Release Notes
+
+```release-note
+NONE
+```


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

- Add the standard Tekton bug, feature, and free-form issue templates.
- Collect Tekton Kueue, Kueue, Pipelines, and Kubernetes versions in bug reports.
- Replace the pre-transfer PR template with the Tekton contributor and release-note checklist.

Part of #527.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
